### PR TITLE
Draft API specification.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,7 @@ dmypy.json
 *.adb.csv
 *.jpg
 *.npy
+
+env3/*
+test/aperturedb/db/*
+test/input/blobs/*

--- a/README.md
+++ b/README.md
@@ -13,3 +13,46 @@ elements in ApertureDB at the object level.
 * NotebookHelpers.py provides helpers to show images/bounding boxes on Jupyter Notebooks
 
 For more information, visit https://aperturedata.io
+
+
+## Object Mapper API
+This API allows the user to interact with the database with the idea of objects that can be Created, Read, Updated and Deleted through an intutive interface involving these objects.
+
+It supports the following types of Objects in the Database as Python objects:
+| Object | Dcumentation |
+| ----- | -----|
+| Blob||
+| BoundingBox || 
+| Descriptor||
+| DescriptorSet||
+| Entity||
+| Image||
+| Video||
+
+
+### Examples
+**Create an Image**
+
+```
+from aperturedb import Connector, Images
+images = Images.Images(db_connector)
+with open(abs_path, "rb") as instream:
+    img_data = instream.read()
+    images.create_new(
+        properties: {
+            description: "A new image API",
+            custom_index: 92
+        }
+    )
+    image = image.save()
+    # image is an object with _uniqueid and arbitrary properties, and methods.
+```
+
+**Retrieve an Image**
+
+```
+from aperturedb import Connector, Images
+images = Images.Images(db_connector)
+
+image = image.get(id=92)
+```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ It supports the following types of Objects in the Database as Python objects:
 
 ```
 from aperturedb import Connector, Images
+
+db_connector = Connector.Connector(user="admin", password="admin")
 images = Images.Images(db_connector)
 with open(abs_path, "rb") as instream:
     img_data = instream.read()
@@ -52,7 +54,24 @@ with open(abs_path, "rb") as instream:
 
 ```
 from aperturedb import Connector, Images
+
+db_connector = Connector.Connector(user="admin", password="admin")
 images = Images.Images(db_connector)
 
 image = image.get(id=92)
+```
+
+**Connect an Image to BoundingBox**
+```
+from aperturedb import Connector, Images, BoundingBoxes
+
+db_connector = Connector.Connector(user="admin", password="admin")
+
+bboxes = BoundingBoxes.BoundingBoxes(db_connector)
+bbox = bboxes.get(id=34)
+
+images = Images.Images(db_connector)
+img = images.get(id=1)
+
+img.connect_BoundingBox(bbox)
 ```

--- a/aperturedb/BoundingBoxes.py
+++ b/aperturedb/BoundingBoxes.py
@@ -1,0 +1,7 @@
+from aperturedb.Repository import Repository
+
+
+class BoundingBoxes(Repository):
+    def __init__(self, db, batch_size=100):
+        super().__init__(db)
+        self._object_type = "BoundingBox"

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -12,6 +12,7 @@ from matplotlib.collections import PatchCollection
 from matplotlib.patches import Polygon
 
 from aperturedb import Status
+from aperturedb.Repository import Repository
 
 class Constraints(object):
 
@@ -68,10 +69,10 @@ class Operations(object):
 
         self.operations_arr.append(op)
 
-class Images(object):
+class Images(Repository):
 
     def __init__(self, db, batch_size=100):
-
+        super().__init__(db)
         self.db_connector = db
 
         self.images        = {}
@@ -91,6 +92,7 @@ class Images(object):
 
         self.img_id_prop     = "_uniqueid"
         self.bbox_label_prop = "_label"
+        self._object_type = "Image"
 
     def __retrieve_batch(self, index):
 

--- a/aperturedb/ObjectHelper.py
+++ b/aperturedb/ObjectHelper.py
@@ -1,0 +1,16 @@
+def dict_to_obj(d, name):
+    """
+    Converts a dict into native object, with keys as properties.
+    Expects a name to be used for the generated type.
+    """
+    top = type(name, (object,), d)
+    seqs = tuple, list, set, frozenset
+    for i, j in d.items():
+        if isinstance(j, dict):
+            setattr(top, i, dict_to_obj(j))
+        elif isinstance(j, seqs):
+            setattr(top, i, 
+                type(j)(dict_to_obj(sj, name) if isinstance(sj, dict) else sj for sj in j))
+        else:
+            setattr(top, i, j)
+    return top

--- a/aperturedb/Repository.py
+++ b/aperturedb/Repository.py
@@ -1,0 +1,154 @@
+from typing import List, Optional, Dict, ByteString
+from aperturedb import Connector, Status, ObjectHelper
+from collections import namedtuple
+
+import types
+
+FIND_COMMAND_PREFIX = "Find"
+ADD_COMMAND_PREFIX = "Add"
+UPDATE_COMMAND_PREFIX = "Update"
+DELETE_COMMAND_PREFIX = "Delete"
+
+all_objects = [
+    "Blob",
+    "BoundingBox",
+    "Descriptor",
+    "DescriptorSet",
+    "Entity",
+    "Image",
+    "Video"
+]
+
+def connect_entity(src, dest):
+    src._findquery["_ref"] = 1
+    dest._findquery["_ref"] = 2
+    connect_command = [
+        src._findquery,
+        dest._findquery,
+        {
+            "AddConnection": {
+                "class": "edge",
+                "src" : 1,
+                "dest" : 2
+            }
+        }
+    ]
+    print(connect_command)
+    resp, blob = src._db.query(connect_command)
+    print(resp)
+
+
+class Repository:
+    def __init__(self, db: Connector.Connector) -> None:
+        self._db = db
+        self._status = Status.Status(db)
+        self._schema = self._status.get_schema()
+        self._object_type = "Entity"
+        if self._object_type in self._schema["entities"]["classes"]:
+            self._properties = [k for k in self._schema["entities"]["classes"][self._object_type]["properties"]]
+        else:
+            self._properties = {}
+        
+    def _find_command(self) -> str:
+        return f"{FIND_COMMAND_PREFIX}{self._object_type}"
+
+    def _add_command(self) -> str:
+        return f"{ADD_COMMAND_PREFIX}{self._object_type}"
+
+    def _create_object(self, resp):
+        # Safe property names. Remove spaces.
+        modified = {k.replace(" ", "_"): v for k,v in resp[0][self._find_command()]["entities"][0].items()}
+        instance = ObjectHelper.dict_to_obj(modified, self._object_type)
+
+        for o in all_objects:
+            setattr(instance, f"connect_{o}", types.MethodType(connect_entity, instance))
+
+        self._entity = instance
+        return instance
+
+    def save(self):
+        """
+        Persist an object in the Database and get its id.
+        
+        """
+        create_query = {
+            self._add_command() : {
+                "properties": self._properties,
+            }
+        }
+        if self._class is not None:
+            create_query[self._add_command()]["class"] = self._class
+        if self._label is not None:
+            create_query[self._add_command()]["label"] = self._label
+        if self._rectangle is not None:
+            create_query[self._add_command()]["rectangle"] = self._rectangle
+
+
+        if self._blob is not None:
+            resp, blob = self._db.query([create_query], [self._blob])
+        else:
+            resp = self._db.query([create_query])
+            
+        retVal = None
+        if 'status' not in resp:
+            # TODO Change the VDMS to return the _uniqueid for all the Add operations.
+            find_query = {
+                self._find_command(): {
+                    "constraints": {
+                        p : ["==", self._properties[p]] for p in self._properties
+                    },
+                    "uniqueids": True,
+                    "results" : {
+                        "all_properties" : True,
+                        "limit": 1
+                    }
+                }
+            }
+            
+            resp, blob = self._db.query([find_query])
+            retVal = self._create_object(resp)
+        else:
+            Error = namedtuple('Error', [k for k in resp])
+            e = Error(**resp)
+            retVal = e
+
+        return retVal
+
+    def get(self, id):
+        """
+        Get a unique Object from the database by it's unique property.
+        """
+        find_query = {
+                self._find_command(): {
+                    "constraints": {
+                        "_uniqueid": ["==", id]
+                    },
+                    "results" : {
+                        "all_properties" : True
+                    }
+                }
+        }
+        resp, blob = self._db.query([find_query])
+        if resp[0][self._find_command()]["returned"] != 1:
+            raise Exception("not found unique entity")
+        entity = self._create_object(resp)
+        setattr(entity, "_findquery", find_query)
+        setattr(entity, "_db", self._db)
+        return entity
+
+    def create_new(self, 
+        properties: Optional[Dict] = {}, 
+        operations: Optional[List[Dict]] = [], 
+        blob: Optional[ByteString] = None,
+        rectangle:Optional[Dict] = None,
+        label: Optional[str] = None,
+        eclass:str=None):
+        """
+        A Create new function discards all previous information
+        """
+        self._properties = properties
+        self._blob = blob
+        self._operations = operations
+        self._class = eclass
+        self._rectangle = rectangle
+        self._label = label

--- a/aperturedb/Repository.py
+++ b/aperturedb/Repository.py
@@ -19,23 +19,25 @@ all_objects = [
     "Video"
 ]
 
-def connect_entity(src, dest):
-    src._findquery["_ref"] = 1
-    dest._findquery["_ref"] = 2
+def connect_entity(src, dst):
+    src._findquery[src._find_command()]["_ref"] = 1
+    dst._findquery[dst._find_command()]["_ref"] = 2
     connect_command = [
         src._findquery,
-        dest._findquery,
+        dst._findquery,
         {
             "AddConnection": {
                 "class": "edge",
                 "src" : 1,
-                "dest" : 2
+                "dst" : 2
             }
         }
     ]
-    print(connect_command)
     resp, blob = src._db.query(connect_command)
-    print(resp)
+    connection = ObjectHelper.dict_to_obj(resp[2]["AddConnection"], "Connection")
+    setattr(connection, "src", src)
+    setattr(connection, "dst", dst)
+    return connection
 
 def delete_entity(entity):
     resp = entity._db.query([entity._deletequery])
@@ -142,6 +144,10 @@ class Repository:
         if resp[0][self._find_command()]["returned"] != 1:
             raise Exception("not found unique entity")
         entity = self._create_object(resp)
+        setattr(entity, "_find_command", self._find_command)
+        setattr(entity, "_add_command", self._add_command)
+        setattr(entity, "_delete_command", self._delete_command)
+
         setattr(entity, "_findquery", find_query)
         setattr(entity, "_deletequery", delete_query)
         setattr(entity, "_db", self._db)

--- a/aperturedb/Repository.py
+++ b/aperturedb/Repository.py
@@ -164,7 +164,7 @@ class Repository:
         self._rectangle = rectangle
         self._label = label
 
-    def filter(self, constraints=None, operations=None, format=None, limit=None):
+    def filter(self, constraints=None, operations=None, format=None, limit=None, getBlobs=False):
         """
         A new search will throw away the results of any previous search
         """
@@ -194,7 +194,8 @@ class Repository:
         query[self._find_command()]["results"]["list"].append(self._id_prop)
 
         # Only retrieve images when needed
-        query[self._find_command()]["blobs"] = False
+        if getBlobs:
+            query[self._find_command()]["blobs"] = False
 
         response, images = self._db.query([query])
 

--- a/test/download_images.py
+++ b/test/download_images.py
@@ -1,7 +1,4 @@
 import argparse
-import random
-import math
-
 from aperturedb import ImageDownloader
 
 def main(params):

--- a/test/test_Image.py
+++ b/test/test_Image.py
@@ -90,7 +90,10 @@ class TestImageMethods(unittest.TestCase):
         bboxes = BoundingBoxes.BoundingBoxes(self.db)
         bbox = bboxes.get(id=box._uniqueid)
         img = self.images.get(id=image._uniqueid)
-        img.connect_BoundingBox(bbox)
+        connection = img.connect_BoundingBox(bbox)
+        self.assertEqual(connection.status, 0)
+        self.assertEqual(connection.src, img)
+        self.assertEqual(connection.dst, bbox)
 
     def test_enumerate(self):
         for image in self.images.filter():

--- a/test/test_Image.py
+++ b/test/test_Image.py
@@ -1,0 +1,97 @@
+from datetime import datetime
+import unittest
+import  os
+from aperturedb import Connector, Images, Repository, Status, BoundingBoxes
+
+class TestImageMethods(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.db = Connector.Connector(user="admin", password="admin")
+        cls.status = Status.Status(cls.db)
+        cls.images = Images.Images(cls.db)
+
+    def create_Bounding_Box(self):
+        bboxes = BoundingBoxes.BoundingBoxes(self.db)
+        bboxes.create_new(
+            label="Plane",
+            properties={
+                "label_id": 43
+            },
+            rectangle={
+                "x": 0,
+                "y": 0,
+                "width": 100,
+                "height": 200
+            }
+        )
+        bbox = bboxes.save()
+        return bbox
+
+    def create_Image(self, path):
+        image = None
+        with open(path, "rb") as instream:
+            img_data = instream.read()
+            self.images.create_new(
+                properties={
+                    "description" : "A first class image",
+                    "timestamp": str(datetime.now()),
+                    "path": path
+                }, 
+                operations=[], 
+                blob=img_data)
+            image = self.images.save()
+        return image            
+
+
+
+    
+    def test_create(self):
+        for i in range(10):
+            file_path = f"input/images/000{i}.jpg"
+            abs_path  = os.path.join(os.path.join( os.path.dirname( __file__) , file_path))
+            image = self.create_Image(abs_path)
+            self.assertTrue(hasattr(image, "_uniqueid"))
+            self.assertTrue(hasattr(image, "description"))
+            self.assertTrue(hasattr(image, "timestamp"))
+
+    def test_getOne(self):
+        image = self.create_Image(os.path.join(os.path.join( os.path.dirname( __file__), "input/images/0000.jpg")))
+        img = self.images.get(id=image._uniqueid)
+        self.assertIsNotNone(img)
+        self.assertEqual(img._uniqueid, image._uniqueid)
+
+    def test_ConnectedObjects(self):
+        entities = Repository.Repository(self.db)
+        entities.create_new(
+            properties={
+                "name": "James Bond",
+                "age": 7,
+                "email": "james@aperturedata.io"
+            },
+            eclass="Person"
+        )
+        entity = entities.save()
+        self.assertTrue(hasattr(entity, "_uniqueid"))
+
+        re_read = entities.get(entity._uniqueid)
+        self.assertIsNotNone(re_read)
+
+    def test_CreateBbox(self):
+        box = self.create_Bounding_Box()
+        self.assertIsNotNone(box)
+        self.assertIsNotNone(getattr(box,"_uniqueid"))
+
+
+    def test_Connect(self):
+        box = self.create_Bounding_Box()
+        image = self.create_Image(os.path.join(os.path.join( os.path.dirname( __file__), "input/images/0000.jpg")))
+        bboxes = BoundingBoxes.BoundingBoxes(self.db)
+        bbox = bboxes.get(id=box._uniqueid)
+        img = self.images.get(id=image._uniqueid)
+        img.connect_BoundingBox(bbox)
+
+        
+
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_Image.py
+++ b/test/test_Image.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import unittest
 import  os
 from aperturedb import Connector, Images, Repository, Status, BoundingBoxes
+from utils import cleanDB
 
 class TestImageMethods(unittest.TestCase):
     @classmethod
@@ -9,6 +10,7 @@ class TestImageMethods(unittest.TestCase):
         cls.db = Connector.Connector(user="admin", password="admin")
         cls.status = Status.Status(cls.db)
         cls.images = Images.Images(cls.db)
+        cleanDB(cls.db)
 
     def create_Bounding_Box(self):
         bboxes = BoundingBoxes.BoundingBoxes(self.db)
@@ -89,6 +91,11 @@ class TestImageMethods(unittest.TestCase):
         bbox = bboxes.get(id=box._uniqueid)
         img = self.images.get(id=image._uniqueid)
         img.connect_BoundingBox(bbox)
+
+    def test_enumerate(self):
+        for image in self.images.filter():
+            self.assertIsNotNone(image)
+            self.assertTrue(hasattr(image, "_uniqueid"))
 
         
 

--- a/test/test_Loaders.py
+++ b/test/test_Loaders.py
@@ -9,8 +9,14 @@ from aperturedb import Connector, Status
 from aperturedb import EntityLoader, ConnectionLoader
 from aperturedb import ImageLoader, BBoxLoader, BlobLoader
 from aperturedb import DescriptorSetLoader, DescriptorLoader
+from utils import cleanDB
 
 class TestLoader(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        db = Connector.Connector(user="admin", password="admin")
+        cleanDB(db)
+
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -46,7 +52,7 @@ class TestLoader(unittest.TestCase):
 
     def create_connection(self):
         return Connector.Connector(self.db_host, self.db_port, self.user, self.password)
-
+        
 class TestEntityLoader(TestLoader):
 
     def test_Loader(self):

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,19 @@
+from aperturedb import Images, Repository
+from aperturedb.BoundingBoxes import BoundingBoxes
+
+
+    
+def cleanDB(db):
+    """
+    Helper function to reset the DB to clean state.
+    """
+    images = Images.Images(db)
+    entities = Repository.Repository(db)
+    bboxes = BoundingBoxes(db)
+    print("Cleaning up DB")
+    for image in images.filter():
+        image.delete()
+    for entity in entities.filter():
+        entity.delete()
+    for bbox in bboxes.filter():
+        bbox.delete()


### PR DESCRIPTION
**Starting to implement an Object mapper API.**
It would enable the users to interact with athena using an API that alleviates the need to be familiar with the [native API](https://docs.aperturedata.io/index.html).

It is going to be designed on the guidelines of a similar ORM library, for example [SQL Alchemy](https://www.sqlalchemy.org/) or [Django's ORM](https://docs.djangoproject.com/en/4.0/topics/db/queries/).

The following are some considerations for implementing it this time:
- It will support CRUD operations for the object types covered by the native API.
- It will treat the Entities in a more or less common way, and implement the basic DB operations (rather than the prescribed ways of actions on these objects.
- The main goal is will be to add simplicity and intuitiveness for interacting with VDMS. The current API requires the users to familiarize themselves with the API.