### PR TITLE
ConnectionLoader_py_fix

### DIFF
--- a/aperturedb/ConnectionLoader.py
+++ b/aperturedb/ConnectionLoader.py
@@ -1,3 +1,4 @@
+import sys
 from aperturedb import ParallelLoader
 from aperturedb import CSVParser
 


### PR DESCRIPTION
### Purpose
Bug/omission fix

### Detail
We use `sys` module without imprting it. Require when an error happens.