### PR TITLE
Set tag before kubectl apply.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,9 @@ jobs:
       - name: GitHub Release
         run: 'TOKEN=${{ secrets.GITHUBPAT }} ./github-release.sh'
         shell: bash
+      - name: Set release version
+        run: './configure_deployment.sh'
+        shell: bash
       - uses: actions-hub/kubectl@master
         env:
           KUBE_CONFIG: ${{ secrets.KUBECONFIG_MICROK8S }}

--- a/configure_deployment.sh
+++ b/configure_deployment.sh
@@ -1,0 +1,11 @@
+set -e
+
+source $(dirname "$0")/version.sh
+
+read_version
+
+echo "Configuring deployment with: $BUILD_VERSION"
+
+
+find deploy/ -type f -name "*.yaml" -exec sed -i "s/\$VERSION/v$BUILD_VERSION/g" {} \;
+

--- a/deploy/aperturedb-python-cc-deployment.yaml
+++ b/deploy/aperturedb-python-cc-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
           - name: aperturedb-python-coverage
-            image: 684446431133.dkr.ecr.us-west-2.amazonaws.com/aperturedb-python-coverage
+            image: 684446431133.dkr.ecr.us-west-2.amazonaws.com/aperturedb-python-coverage:$VERSION
             ports:
               - containerPort: 80
             resources: {}

--- a/deploy/aperturedb-python-docs-deployment.yaml
+++ b/deploy/aperturedb-python-docs-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
           - name: aperturedb-python-docs
-            image: 684446431133.dkr.ecr.us-west-2.amazonaws.com/aperturedb-python-docs
+            image: 684446431133.dkr.ecr.us-west-2.amazonaws.com/aperturedb-python-docs:$VERSION
             ports:
               - containerPort: 80
             resources: {}


### PR DESCRIPTION
Since we do not maintain a 'latest' image in the ECR. We'll specify the tag from the release being created. 