### PR TITLE
autogenerate indices using parallel loader

### DIFF
--- a/aperturedb/BBoxDataCSV.py
+++ b/aperturedb/BBoxDataCSV.py
@@ -60,21 +60,21 @@ class BBoxDataCSV(CSVParser.CSVParser):
     def __init__(self, filename, df=None, use_dask=False):
 
         super().__init__(filename, df=df, use_dask=use_dask)
-        if not use_dask:
-            self.props_keys       = [x for x in self.header[5:]
-                                     if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
-            self.constraints_keys = [x for x in self.header[5:]
-                                     if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
 
-            self.img_key = self.header[0]
-            self.command = "AddBoundingBox"
+        self.props_keys = [x for x in self.header[5:]
+                           if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
+        self.constraints_keys = [x for x in self.header[5:]
+                                 if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
+
+        self.img_key = self.header[0]
+        self.command = "AddBoundingBox"
 
     def get_indices(self):
-        return [{
-            "index_type": "entity",
-            "class": "_BoundingBox",
-            "property": prop
-        } for prop in self.constraints_keys]
+        return {
+            "entity": {
+                "_BoundingBox": self.get_indexed_properties()
+            }
+        }
 
     def getitem(self, idx):
         idx = self.df.index.start + idx

--- a/aperturedb/BBoxDataCSV.py
+++ b/aperturedb/BBoxDataCSV.py
@@ -69,6 +69,13 @@ class BBoxDataCSV(CSVParser.CSVParser):
             self.img_key = self.header[0]
             self.command = "AddBoundingBox"
 
+    def get_indices(self):
+        return [{
+            "index_type": "entity",
+            "class": "_BoundingBox",
+            "property": prop
+        } for prop in self.constraints_keys]
+
     def getitem(self, idx):
         idx = self.df.index.start + idx
 

--- a/aperturedb/BBoxDataCSV.py
+++ b/aperturedb/BBoxDataCSV.py
@@ -110,7 +110,7 @@ class BBoxDataCSV(CSVParser.CSVParser):
         }
         abb = self._basic_command(idx, custom_fields)
 
-        properties  = self.parse_properties(self.df, idx)
+        properties = self.parse_properties(idx)
         if properties:
             props = properties
             if "_label" in props:

--- a/aperturedb/BlobDataCSV.py
+++ b/aperturedb/BlobDataCSV.py
@@ -57,6 +57,13 @@ class BlobDataCSV(CSVParser.CSVParser):
                                      if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
             self.command = "AddBlob"
 
+    def get_indices(self):
+        return [{
+            "index_type": "entity",
+            "class": "_Blob",
+            "property": prop
+        } for prop in self.constraints_keys]
+
     def getitem(self, idx):
         idx = self.df.index.start + idx
         filename = self.df.loc[idx, BLOB_PATH]

--- a/aperturedb/BlobDataCSV.py
+++ b/aperturedb/BlobDataCSV.py
@@ -50,19 +50,19 @@ class BlobDataCSV(CSVParser.CSVParser):
     def __init__(self, filename, df=None, use_dask=False):
 
         super().__init__(filename, df=df, use_dask=use_dask)
-        if not use_dask:
-            self.props_keys       = [x for x in self.header[1:]
-                                     if not x.startswith(CSVParser.CONSTRAINTS_PREFIX) and x != BLOB_PATH]
-            self.constraints_keys = [x for x in self.header[1:]
-                                     if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
-            self.command = "AddBlob"
+
+        self.props_keys = [x for x in self.header[1:]
+                           if not x.startswith(CSVParser.CONSTRAINTS_PREFIX) and x != BLOB_PATH]
+        self.constraints_keys = [x for x in self.header[1:]
+                                 if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
+        self.command = "AddBlob"
 
     def get_indices(self):
-        return [{
-            "index_type": "entity",
-            "class": "_Blob",
-            "property": prop
-        } for prop in self.constraints_keys]
+        return {
+            "entity": {
+                "_Blob": self.get_indexed_properties()
+            }
+        }
 
     def getitem(self, idx):
         idx = self.df.index.start + idx

--- a/aperturedb/CSVParser.py
+++ b/aperturedb/CSVParser.py
@@ -32,11 +32,9 @@ class CSVParser(Subscriptable):
         So the Data CSV has another signature, where the df is passed explicitly.
     """
 
-    def __init__(self, filename, index_class=None, index_type="entity", df=None, use_dask=False):
+    def __init__(self, filename, df=None, use_dask=False):
         self.use_dask = use_dask
         self.filename = filename
-        self.index_class = index_class
-        self.index_type = index_type
 
         if not use_dask:
             if df is None:
@@ -64,35 +62,6 @@ class CSVParser(Subscriptable):
 
     def get_indices(self):
         raise NotImplementedError
-
-    # def _create_indices(self, db):
-    #     if len(self.constraints_keys) == 0:
-    #         return
-
-    #     schema_result, _ = db.query([{"GetSchema": {}}])
-    #     try:
-    #         plural_index_type = "entities" if self.index_type == "entity" else "connections"
-    #         existing_indices = {
-    #             k for k in schema_result[0]["GetSchema"][plural_index_type]["classes"][self.index_class].keys()}
-    #     except:
-    #         existing_indices = set()
-
-    #     new_indices = self.constraints_keys - existing_indices
-    #     if len(new_indices) == 0:
-    #         return
-
-    #     logger.info(
-    #         f"Creating {self.index_type} indices of class '{self.index_class}' for properties {new_indices}.")
-
-    #     create_indices = [{"CreateIndex": {
-    #         "index_type":   self.index_type,
-    #         "class":        self.index_class,
-    #         "property_key": key}} for key in new_indices]
-
-    #     res, _ = db.query(create_indices)
-
-    #     if self.check_status(res) != 0:
-    #         logger.warn("Failed to create indices; ingestion will be slow.")
 
     def parse_properties(self, df, idx):
 

--- a/aperturedb/CSVParser.py
+++ b/aperturedb/CSVParser.py
@@ -60,6 +60,11 @@ class CSVParser(Subscriptable):
     def __len__(self):
         return len(self.df.index)
 
+    def get_indexed_properties(self):
+        if self.constraints_keys:
+            return {k[len(CONSTRAINTS_PREFIX):] for k in self.constraints_keys}
+        return set()
+
     def get_indices(self):
         raise NotImplementedError
 

--- a/aperturedb/CSVParser.py
+++ b/aperturedb/CSVParser.py
@@ -32,9 +32,11 @@ class CSVParser(Subscriptable):
         So the Data CSV has another signature, where the df is passed explicitly.
     """
 
-    def __init__(self, filename, df=None, use_dask=False):
+    def __init__(self, filename, index_class=None, index_type="entity", df=None, use_dask=False):
         self.use_dask = use_dask
         self.filename = filename
+        self.index_class = index_class
+        self.index_type = index_type
 
         if not use_dask:
             if df is None:
@@ -59,6 +61,38 @@ class CSVParser(Subscriptable):
 
     def __len__(self):
         return len(self.df.index)
+
+    def get_indices(self):
+        raise NotImplementedError
+
+    # def _create_indices(self, db):
+    #     if len(self.constraints_keys) == 0:
+    #         return
+
+    #     schema_result, _ = db.query([{"GetSchema": {}}])
+    #     try:
+    #         plural_index_type = "entities" if self.index_type == "entity" else "connections"
+    #         existing_indices = {
+    #             k for k in schema_result[0]["GetSchema"][plural_index_type]["classes"][self.index_class].keys()}
+    #     except:
+    #         existing_indices = set()
+
+    #     new_indices = self.constraints_keys - existing_indices
+    #     if len(new_indices) == 0:
+    #         return
+
+    #     logger.info(
+    #         f"Creating {self.index_type} indices of class '{self.index_class}' for properties {new_indices}.")
+
+    #     create_indices = [{"CreateIndex": {
+    #         "index_type":   self.index_type,
+    #         "class":        self.index_class,
+    #         "property_key": key}} for key in new_indices]
+
+    #     res, _ = db.query(create_indices)
+
+    #     if self.check_status(res) != 0:
+    #         logger.warn("Failed to create indices; ingestion will be slow.")
 
     def parse_properties(self, df, idx):
 

--- a/aperturedb/CSVParser.py
+++ b/aperturedb/CSVParser.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 ENTITY_CLASS      = "EntityClass"
 CONSTRAINTS_PREFIX = "constraint_"
+DATE_PREFIX = "date:"
 PROPERTIES  = "properties"
 CONSTRAINTS = "constraints"
 
@@ -62,48 +63,46 @@ class CSVParser(Subscriptable):
 
     def get_indexed_properties(self):
         if self.constraints_keys:
-            return {k[len(CONSTRAINTS_PREFIX):] for k in self.constraints_keys}
+            return {self._parse_prop(k)[0] for k in self.constraints_keys}
         return set()
 
     def get_indices(self):
         raise NotImplementedError
 
-    def parse_properties(self, df, idx):
+    def _parse_prop(self, key, val=None):
+        if key.startswith(CONSTRAINTS_PREFIX):
+            key = key[len(CONSTRAINTS_PREFIX):]
+        if key.startswith(DATE_PREFIX):
+            key = key[len(DATE_PREFIX):]
+            val = {"_date": val}
+        return key, val
+
+    def parse_properties(self, idx):
 
         properties = {}
-        if len(self.props_keys) > 0:
+        if self.props_keys:
             for key in self.props_keys:
-                # Handle Date data type
-                if key.startswith("date:"):
-                    prop = key[len("date:"):]  # remove prefix
-                    properties[prop] = {"_date": self.df.loc[idx, key]}
-                else:
-                    value = self.df.loc[idx, key]
-                    if value == value:  # skips nan values
-                        properties[key] = value
+                prop, value = self._parse_prop(key, self.df.loc[idx, key])
+                if value == value:  # skips nan values
+                    properties[prop] = value
 
         return properties
 
-    def parse_constraints(self, df, idx):
+    def parse_constraints(self, idx):
 
         constraints = {}
-        if len(self.constraints_keys) > 0:
+        if self.constraints_keys:
             for key in self.constraints_keys:
-                if key.startswith("constraint_date:"):
-                    prop = key[len("constraint_date:"):]  # remove prefix
-                    constraints[prop] = [
-                        "==", {"_date": self.df.loc[idx, key]}]
-                else:
-                    prop = key[len(CONSTRAINTS_PREFIX):]  # remove "prefix
-                    constraints[prop] = ["==", self.df.loc[idx, key]]
+                prop, value = self._parse_prop(key, self.df.loc[idx, key])
+                constraints[prop] = ["==", value]
 
         return constraints
 
     def _basic_command(self, idx, custom_fields: dict = None):
         if custom_fields == None:
             custom_fields = {}
-        properties = self.parse_properties(self.df, idx)
-        constraints = self.parse_constraints(self.df, idx)
+        properties = self.parse_properties(idx)
+        constraints = self.parse_constraints(idx)
         query = {
             self.command: custom_fields
         }

--- a/aperturedb/ConnectionDataCSV.py
+++ b/aperturedb/ConnectionDataCSV.py
@@ -56,26 +56,26 @@ class ConnectionDataCSV(CSVParser):
 
     def __init__(self, filename, df=None, use_dask=False):
         super().__init__(filename, df=df, use_dask=use_dask)
-        if not use_dask:
-            self.props_keys       = [x for x in self.header[3:]
-                                     if not x.startswith(CONSTRAINTS_PREFIX)]
 
-            self.constraints_keys = [x for x in self.header[3:]
-                                     if x.startswith(CONSTRAINTS_PREFIX)]
+        self.props_keys       = [x for x in self.header[3:]
+                                    if not x.startswith(CONSTRAINTS_PREFIX)]
 
-            self.src_class   = self.header[1].split("@")[0]
-            self.src_key     = self.header[1].split("@")[1]
-            self.dst_class   = self.header[2].split("@")[0]
-            # Pandas appends a .n to the column name if there is a duplicate
-            self.dst_key     = self.header[2].split("@")[1].split(".")[0]
-            self.command     = "AddConnection"
+        self.constraints_keys = [x for x in self.header[3:]
+                                    if x.startswith(CONSTRAINTS_PREFIX)]
+
+        self.src_class   = self.header[1].split("@")[0]
+        self.src_key     = self.header[1].split("@")[1]
+        self.dst_class   = self.header[2].split("@")[0]
+        # Pandas appends a .n to the column name if there is a duplicate
+        self.dst_key     = self.header[2].split("@")[1].split(".")[0]
+        self.command     = "AddConnection"
 
     def get_indices(self):
-        return [{
-            "index_type": "connection",
-            "class": cls,
-            "property": prop
-        } for prop in self.constraints_keys for cls in self.df[CONNECTION_CLASS].unique()]
+        return {
+            "connection": {
+                cls: self.get_indexed_properties() for cls in self.df[CONNECTION_CLASS].unique()
+            }
+        }
 
     def getitem(self, idx):
         idx = self.df.index.start + idx

--- a/aperturedb/ConnectionDataCSV.py
+++ b/aperturedb/ConnectionDataCSV.py
@@ -68,7 +68,7 @@ class ConnectionDataCSV(CSVParser):
             self.dst_class   = self.header[2].split("@")[0]
             # Pandas appends a .n to the column name if there is a duplicate
             self.dst_key     = self.header[2].split("@")[1].split(".")[0]
-            self.command = "AddConnection"
+            self.command     = "AddConnection"
 
     def get_indices(self):
         return [{

--- a/aperturedb/ConnectionDataCSV.py
+++ b/aperturedb/ConnectionDataCSV.py
@@ -58,10 +58,10 @@ class ConnectionDataCSV(CSVParser):
         super().__init__(filename, df=df, use_dask=use_dask)
 
         self.props_keys       = [x for x in self.header[3:]
-                                    if not x.startswith(CONSTRAINTS_PREFIX)]
+                                 if not x.startswith(CONSTRAINTS_PREFIX)]
 
         self.constraints_keys = [x for x in self.header[3:]
-                                    if x.startswith(CONSTRAINTS_PREFIX)]
+                                 if x.startswith(CONSTRAINTS_PREFIX)]
 
         self.src_class   = self.header[1].split("@")[0]
         self.src_key     = self.header[1].split("@")[1]

--- a/aperturedb/ConnectionDataCSV.py
+++ b/aperturedb/ConnectionDataCSV.py
@@ -68,7 +68,14 @@ class ConnectionDataCSV(CSVParser):
             self.dst_class   = self.header[2].split("@")[0]
             # Pandas appends a .n to the column name if there is a duplicate
             self.dst_key     = self.header[2].split("@")[1].split(".")[0]
-            self.command     = "AddConnection"
+            self.command = "AddConnection"
+
+    def get_indices(self):
+        return [{
+            "index_type": "connection",
+            "class": cls,
+            "property": prop
+        } for prop in self.constraints_keys for cls in self.df[CONNECTION_CLASS].unique()]
 
     def getitem(self, idx):
         idx = self.df.index.start + idx

--- a/aperturedb/DescriptorDataCSV.py
+++ b/aperturedb/DescriptorDataCSV.py
@@ -73,19 +73,19 @@ class DescriptorDataCSV(CSVParser.CSVParser):
         super().__init__(filename, df=df, use_dask=use_dask)
         self.npy_arrays = {}
         self.has_label = False
-        if not use_dask:
-            self.props_keys       = [x for x in self.header[3:]
-                                     if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
-            self.constraints_keys = [x for x in self.header[3:]
-                                     if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
-            self.command = "AddDescriptor"
+
+        self.props_keys       = [x for x in self.header[3:]
+                                    if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
+        self.constraints_keys = [x for x in self.header[3:]
+                                    if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
+        self.command = "AddDescriptor"
 
     def get_indices(self):
-        return [{
-            "index_type": "entity",
-            "class": "_Descriptor",
-            "property": prop
-        } for prop in self.constraints_keys]
+        return {
+            "entity": {
+                "_Descriptor": self.get_indexed_properties()
+            }
+        }
 
     def getitem(self, idx):
         idx = self.df.index.start + idx

--- a/aperturedb/DescriptorDataCSV.py
+++ b/aperturedb/DescriptorDataCSV.py
@@ -80,6 +80,13 @@ class DescriptorDataCSV(CSVParser.CSVParser):
                                      if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
             self.command = "AddDescriptor"
 
+    def get_indices(self):
+        return [{
+            "index_type": "entity",
+            "class": "_Descriptor",
+            "property": prop
+        } for prop in self.constraints_keys]
+
     def getitem(self, idx):
         idx = self.df.index.start + idx
         filename = self.df.loc[idx, HEADER_PATH]

--- a/aperturedb/DescriptorDataCSV.py
+++ b/aperturedb/DescriptorDataCSV.py
@@ -75,9 +75,9 @@ class DescriptorDataCSV(CSVParser.CSVParser):
         self.has_label = False
 
         self.props_keys       = [x for x in self.header[3:]
-                                    if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
+                                 if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
         self.constraints_keys = [x for x in self.header[3:]
-                                    if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
+                                 if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
         self.command = "AddDescriptor"
 
     def get_indices(self):

--- a/aperturedb/DescriptorSetDataCSV.py
+++ b/aperturedb/DescriptorSetDataCSV.py
@@ -55,6 +55,13 @@ class DescriptorSetDataCSV(CSVParser.CSVParser):
                                      if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
             self.command = "AddDescriptorSet"
 
+    def get_indices(self):
+        return [{
+            "index_type": "entity",
+            "class": "_DescriptorSet",
+            "property": prop
+        } for prop in self.constraints_keys]
+
     def getitem(self, idx):
 
         # Metrics/Engine can be of the form:

--- a/aperturedb/DescriptorSetDataCSV.py
+++ b/aperturedb/DescriptorSetDataCSV.py
@@ -48,19 +48,19 @@ class DescriptorSetDataCSV(CSVParser.CSVParser):
     def __init__(self, filename, df=None, use_dask=False):
 
         super().__init__(filename, df=df, use_dask=use_dask)
-        if not use_dask:
-            self.props_keys       = [x for x in self.header[4:]
-                                     if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
-            self.constraints_keys = [x for x in self.header[4:]
-                                     if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
-            self.command = "AddDescriptorSet"
+
+        self.props_keys = [x for x in self.header[4:]
+                           if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
+        self.constraints_keys = [x for x in self.header[4:]
+                                 if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
+        self.command = "AddDescriptorSet"
 
     def get_indices(self):
-        return [{
-            "index_type": "entity",
-            "class": "_DescriptorSet",
-            "property": prop
-        } for prop in self.constraints_keys]
+        return {
+            "entity": {
+                "_DescriptorSet": self.get_indexed_properties()
+            }
+        }
 
     def getitem(self, idx):
 

--- a/aperturedb/EntityDataCSV.py
+++ b/aperturedb/EntityDataCSV.py
@@ -48,6 +48,13 @@ class EntityDataCSV(CSVParser.CSVParser):
                                      if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
             self.command = "AddEntity"
 
+    def get_indices(self):
+        return [{
+            "index_type": "entity",
+            "class": cls,
+            "property": prop
+        } for prop in self.constraints_keys for cls in self.df[ENTITY_CLASS].unique()]
+
     def getitem(self, idx):
         idx = self.df.index.start + idx
         eclass = self.df.loc[idx, ENTITY_CLASS]

--- a/aperturedb/EntityDataCSV.py
+++ b/aperturedb/EntityDataCSV.py
@@ -41,19 +41,19 @@ class EntityDataCSV(CSVParser.CSVParser):
 
     def __init__(self, filename, df=None, use_dask=False):
         super().__init__(filename, df=df, use_dask=use_dask)
-        if not use_dask:
-            self.props_keys       = [x for x in self.header[1:]
-                                     if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
-            self.constraints_keys = [x for x in self.header[1:]
-                                     if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
-            self.command = "AddEntity"
+
+        self.props_keys = [x for x in self.header[1:]
+                           if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
+        self.constraints_keys = [x for x in self.header[1:]
+                                 if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
+        self.command = "AddEntity"
 
     def get_indices(self):
-        return [{
-            "index_type": "entity",
-            "class": cls,
-            "property": prop
-        } for prop in self.constraints_keys for cls in self.df[ENTITY_CLASS].unique()]
+        return {
+            "entity": {
+                cls: self.get_indexed_properties() for cls in self.df[ENTITY_CLASS].unique()
+            }
+        }
 
     def getitem(self, idx):
         idx = self.df.index.start + idx

--- a/aperturedb/ImageDataCSV.py
+++ b/aperturedb/ImageDataCSV.py
@@ -97,6 +97,13 @@ class ImageDataCSV(CSVParser.CSVParser):
             self.n_download_retries = n_download_retries
             self.command = "AddImage"
 
+    def get_indices(self):
+        return [{
+            "index_type": "entity",
+            "class": "_Image",
+            "property": prop
+        } for prop in self.constraints_keys]
+
     def getitem(self, idx):
         idx = self.df.index.start + idx
         image_path = self.df.loc[idx, self.source_type]

--- a/aperturedb/ImageDataCSV.py
+++ b/aperturedb/ImageDataCSV.py
@@ -76,33 +76,33 @@ class ImageDataCSV(CSVParser.CSVParser):
         super().__init__(filename, df=df, use_dask=use_dask)
 
         self.check_image = check_image
-        if not use_dask:
-            self.format_given     = IMG_FORMAT in self.header
-            self.props_keys       = [x for x in self.header[1:]
-                                     if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
-            self.props_keys       = [
-                x for x in self.props_keys if x != IMG_FORMAT]
-            self.constraints_keys = [x for x in self.header[1:]
-                                     if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
 
-            self.source_type      = self.header[0]
+        self.format_given     = IMG_FORMAT in self.header
+        self.props_keys       = [x for x in self.header[1:]
+                                    if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
+        self.props_keys       = [
+            x for x in self.props_keys if x != IMG_FORMAT]
+        self.constraints_keys = [x for x in self.header[1:]
+                                    if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
 
-            if self.source_type not in self.source_types:
-                logger.error("Source not recognized: " + self.source_type)
-                raise Exception("Error loading image: " + filename)
-            self.source_loader    = {
-                st: sl for st, sl in zip(self.source_types, self.loaders)
-            }
+        self.source_type      = self.header[0]
 
-            self.n_download_retries = n_download_retries
-            self.command = "AddImage"
+        if self.source_type not in self.source_types:
+            logger.error("Source not recognized: " + self.source_type)
+            raise Exception("Error loading image: " + filename)
+        self.source_loader    = {
+            st: sl for st, sl in zip(self.source_types, self.loaders)
+        }
+
+        self.n_download_retries = n_download_retries
+        self.command = "AddImage"
 
     def get_indices(self):
-        return [{
-            "index_type": "entity",
-            "class": "_Image",
-            "property": prop
-        } for prop in self.constraints_keys]
+        return {
+            "entity": {
+                "_Image": self.get_indexed_properties()
+            }
+        }
 
     def getitem(self, idx):
         idx = self.df.index.start + idx

--- a/aperturedb/ImageDataCSV.py
+++ b/aperturedb/ImageDataCSV.py
@@ -79,11 +79,11 @@ class ImageDataCSV(CSVParser.CSVParser):
 
         self.format_given     = IMG_FORMAT in self.header
         self.props_keys       = [x for x in self.header[1:]
-                                    if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
+                                 if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
         self.props_keys       = [
             x for x in self.props_keys if x != IMG_FORMAT]
         self.constraints_keys = [x for x in self.header[1:]
-                                    if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
+                                 if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
 
         self.source_type      = self.header[0]
 

--- a/aperturedb/ParallelLoader.py
+++ b/aperturedb/ParallelLoader.py
@@ -65,9 +65,11 @@ class ParallelLoader(ParallelQuery.ParallelQuery):
                 "Failed to create indices; ingestion will be slow.")
             logger.warning(res)
 
-    def ingest(self, generator, batchsize=1, numthreads=4, stats=False):
+    def query_setup(self, generator):
         if hasattr(generator, "get_indices"):
             self.create_indices(generator.get_indices())
+
+    def ingest(self, generator, batchsize=1, numthreads=4, stats=False):
         logger.info(
             f"Starting ingestion with batchsize={batchsize}, numthreads={numthreads}")
         self.query(generator, batchsize, numthreads, stats)

--- a/aperturedb/ParallelLoader.py
+++ b/aperturedb/ParallelLoader.py
@@ -20,8 +20,8 @@ class ParallelLoader(ParallelQuery.ParallelQuery):
         schema_result, _ = self.db.query([{"GetSchema": {}}])
         schema = schema_result[0]["GetSchema"]
         existing_indices = set()
-        for index_type in (("entity", "entities"), ("connection", "connections")):
-            if index_type[1] in schema and "classes" in schema[index_type[1]]:
+        for index_type in [["entity", "entities"], ["connection", "connections"]]:
+            if (index_type[1] in schema) and ("classes" in schema[index_type[1]]):
                 for cls_name, cls_schema in enumerate(schema[index_type[1]]["classes"]):
                     if "properties" in cls_schema:
                         for prop_name, prop_schema in enumerate(cls_schema):

--- a/aperturedb/ParallelLoader.py
+++ b/aperturedb/ParallelLoader.py
@@ -21,16 +21,17 @@ class ParallelLoader(ParallelQuery.ParallelQuery):
         schema = schema_result[0]["GetSchema"]
         existing_indices = set()
         for index_type in [["entity", "entities"], ["connection", "connections"]]:
-            if (index_type[1] in schema) and ("classes" in schema[index_type[1]]):
-                for cls_name, cls_schema in enumerate(schema[index_type[1]]["classes"]):
-                    if "properties" in cls_schema:
-                        for prop_name, prop_schema in enumerate(cls_schema):
-                            if prop_schema[1]:  # indicates property has an index
-                                existing_indices.add({
-                                    "index_type": index_type[0],
-                                    "class": cls_name,
-                                    "property": prop_name
-                                })
+            if index_type[1] in schema:
+                if "classes" in schema[index_type[1]]:
+                    for cls_name, cls_schema in enumerate(schema[index_type[1]]["classes"]):
+                        if "properties" in cls_schema:
+                            for prop_name, prop_schema in enumerate(cls_schema):
+                                if prop_schema[1]:  # indicates property has an index
+                                    existing_indices.add({
+                                        "index_type": index_type[0],
+                                        "class": cls_name,
+                                        "property": prop_name
+                                    })
 
     def create_indices(self, indices):
         if len(indices) == 0:

--- a/aperturedb/ParallelLoader.py
+++ b/aperturedb/ParallelLoader.py
@@ -22,10 +22,10 @@ class ParallelLoader(ParallelQuery.ParallelQuery):
         existing_indices = set()
         for index_type in [["entity", "entities"], ["connection", "connections"]]:
             if index_type[1] in schema:
-                if "classes" in schema[index_type[1]]:
-                    for cls_name, cls_schema in enumerate(schema[index_type[1]]["classes"]):
+                if "classes" in schema[index_type[1]] or {}:
+                    for cls_name, cls_schema in enumerate(schema[index_type[1]]["classes"] or {}):
                         if "properties" in cls_schema:
-                            for prop_name, prop_schema in enumerate(cls_schema):
+                            for prop_name, prop_schema in enumerate(cls_schema or {}):
                                 if prop_schema[1]:  # indicates property has an index
                                     existing_indices.add({
                                         "index_type": index_type[0],

--- a/aperturedb/ParallelLoader.py
+++ b/aperturedb/ParallelLoader.py
@@ -2,7 +2,6 @@
 from aperturedb import ParallelQuery
 
 import numpy as np
-import json
 import logging
 logger = logging.getLogger(__name__)
 

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -207,10 +207,15 @@ class ParallelQuery(Parallelizer.Parallelizer):
             stats (bool, optional): Show statistics at end of ingestion. Defaults to False.
         """
 
-        if hasattr(generator, "use_dask") and generator.use_dask:
+        use_dask = hasattr(generator, "use_dask") and generator.use_dask
+        if use_dask:
             self._reset(batchsize=batchsize, numthreads=numthreads)
             self.daskmanager = DaskManager(num_workers=numthreads)
 
+        if hasattr(self, "query_setup"):
+            self.query_setup(generator)
+
+        if use_dask:
             results, self.total_actions_time = self.daskmanager.run(
                 self.db, generator, batchsize, stats=stats)
             for result in results:

--- a/aperturedb/Parallelizer.py
+++ b/aperturedb/Parallelizer.py
@@ -70,7 +70,8 @@ class Parallelizer:
         a = [th.join() for th in thread_arr]
 
         # Update progress bar to completion
-        self.pb.update(1)
+        if self.stats:
+            self.pb.update(1)
 
         self.total_actions_time = time.time() - start_time
 

--- a/aperturedb/PolygonDataCSV.py
+++ b/aperturedb/PolygonDataCSV.py
@@ -70,6 +70,13 @@ class PolygonDataCSV(CSVParser.CSVParser):
         self.img_key = self.header[0]
         self.command = "AddPolygon"
 
+    def get_indices(self):
+        return [{
+            "index_type": "entity",
+            "class": "_Polygon",
+            "property": prop
+        } for prop in self.constraints_keys]
+
     def getitem(self, idx):
         idx = self.df.index.start + idx
 

--- a/aperturedb/PolygonDataCSV.py
+++ b/aperturedb/PolygonDataCSV.py
@@ -71,11 +71,11 @@ class PolygonDataCSV(CSVParser.CSVParser):
         self.command = "AddPolygon"
 
     def get_indices(self):
-        return [{
-            "index_type": "entity",
-            "class": "_Polygon",
-            "property": prop
-        } for prop in self.constraints_keys]
+        return {
+            "entity": {
+                "_Polygon": self.get_indexed_properties()
+            }
+        }
 
     def getitem(self, idx):
         idx = self.df.index.start + idx

--- a/aperturedb/VideoDataCSV.py
+++ b/aperturedb/VideoDataCSV.py
@@ -52,11 +52,11 @@ class VideoDataCSV(CSVParser.CSVParser):
         self.command = "AddVideo"
 
     def get_indices(self):
-        return [{
-            "index_type": "entity",
-            "class": "_Video",
-            "property": prop
-        } for prop in self.constraints_keys]
+        return {
+            "entity": {
+                "_Video": self.get_indexed_properties()
+            }
+        }
 
     def getitem(self, idx):
         filename   = self.df.loc[idx, HEADER_PATH]

--- a/aperturedb/VideoDataCSV.py
+++ b/aperturedb/VideoDataCSV.py
@@ -51,6 +51,13 @@ class VideoDataCSV(CSVParser.CSVParser):
                                  if x.startswith(CSVParser.CONSTRAINTS_PREFIX)]
         self.command = "AddVideo"
 
+    def get_indices(self):
+        return [{
+            "index_type": "entity",
+            "class": "_Video",
+            "property": prop
+        } for prop in self.constraints_keys]
+
     def getitem(self, idx):
         filename   = self.df.loc[idx, HEADER_PATH]
         video_ok, video = self.load_video(filename)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -88,6 +88,16 @@ def insert_data_from_csv(db, request):
                       numthreads=8,
                       stats=True,
                       )
+
+        # make sure all indices are present
+        if hasattr(data, "get_indices"):
+            expected_indices = data.get_indices()
+            observed_indices = loader.get_existing_indices()
+            for tp, classes in expected_indices.items():
+                for cls, props in classes.items():
+                    for prop in props:
+                        assert prop in observed_indices[tp][cls]
+
         assert loader.error_counter == 0
         # Preserve loader so that dask manager is not auto deleted.
         # ---------------

--- a/test/run_test_container.sh
+++ b/test/run_test_container.sh
@@ -3,7 +3,7 @@
 set -u
 set -e
 
-docker compose down
+docker compose down --remove-orphans
 rm -rf aperturedb/db
 rm -rf output
 mkdir -m 777 output


### PR DESCRIPTION
When using data loaders, it will attempt to create an index for any property we use for conditional add (ie. with `constraint_` prefix), if it is not already indexed.

Fixes #136 