### PR TITLE
updating docs builder to ubuntu 22

### DIFF
--- a/docs/docker/Dockerfile
+++ b/docs/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as docs
+FROM ubuntu:22.04 as docs
 
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This is causing [CI failure](https://github.com/aperture-data/aperturedb-python/actions/runs/5139222602/jobs/9249429931). 