### PR TITLE
Fix get_similar_images on Images.py

### DIFF
--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -418,7 +418,6 @@ class Images(Entities):
                     "k_neighbors": n_neighbors + 1,
                     "blobs":     False,
                     "distances": True,
-                    "ids":       True,
                     "uniqueids": True,
                 }
             }, {


### PR DESCRIPTION
There was an API change on ApertureDB that no longer accepts `ids` as parameter of FindDescriptor. 