### PR TITLE
revert adb version pin

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   aperturedb:
-    image: aperturedata/aperturedb:v0.15.1
+    image: aperturedata/aperturedb
     volumes:
       - ./aperturedb:/aperturedb
     ports:


### PR DESCRIPTION
Removes the version pin that was introduced to work around https://github.com/aperture-data/athena/issues/1026