### PR TITLE
Add pytest marks and mark checker

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import mark_checker
 from aperturedb.Connector import Connector
 from aperturedb.ConnectorRest import ConnectorRest
 from aperturedb.ParallelLoader import ParallelLoader
@@ -147,3 +148,5 @@ def retired_persons(db, insert_data_from_csv, utils):
     retired_persons = Entities.retrieve(db,
                                         spec=Query.spec(with_class="Person", constraints=constraints))
     return retired_persons
+def pytest_configure(config):
+    mark_checker.store_config(config)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -148,5 +148,7 @@ def retired_persons(db, insert_data_from_csv, utils):
     retired_persons = Entities.retrieve(db,
                                         spec=Query.spec(with_class="Person", constraints=constraints))
     return retired_persons
+
+
 def pytest_configure(config):
     mark_checker.store_config(config)

--- a/test/mark_checker.py
+++ b/test/mark_checker.py
@@ -1,0 +1,27 @@
+# mark_checker.py - checks if a mark is enabled
+from pytest import Session,Config,Item
+
+local_config = None
+def store_config(config):
+    global local_config
+    local_config = config
+
+def is_enabled(test_mark):
+    global local_config
+    # create a config just using commandline args.
+    c = local_config.fromdictargs( dict(), local_config.invocation_params.args  )
+    #raise Exception( str(c.getini("filterwarnings")) + " vs " + str(local_config.getini("filterwarnings")))
+    s = Session.from_config(c)
+    test_item = Item.from_parent( s, name= f"modulehere_test_{test_mark}")
+    # add marker with given mark to this test.
+    if isinstance( test_mark, (list,tuple)):
+        for iter_mark in test_mark:
+            test_item.add_marker(iter_mark)
+    else:
+        test_item.add_marker(test_mark)
+    items = [test_item]
+    # pytest/mark modifies items based on supplied args.
+    local_config.hook.pytest_collection_modifyitems(session=s,config=c,items=items)
+    # if pymark has removed them all of them, that means either positive selections or negative selections
+    # have disabled this test
+    return len(items) > 0

--- a/test/mark_checker.py
+++ b/test/mark_checker.py
@@ -29,6 +29,5 @@ def is_enabled(test_mark):
     # pytest/mark modifies items based on supplied args.
     local_config.hook.pytest_collection_modifyitems(
         session=s, config=c, items=items)
-    # if pymark has removed them all of them, that means either positive selections or negative selections
-    # have disabled this test
-    return len(items) == required
+    # if item is remaining, test would be run.
+    return len(items) == 1

--- a/test/mark_checker.py
+++ b/test/mark_checker.py
@@ -1,21 +1,24 @@
 # mark_checker.py - checks if a mark is enabled
-from pytest import Session,Config,Item
+from pytest import Session, Config, Item
 
 local_config = None
+
+
 def store_config(config):
     global local_config
     local_config = config
 
+
 def is_enabled(test_mark):
     global local_config
     # create a config just using commandline args.
-    c = local_config.fromdictargs( dict(), local_config.invocation_params.args  )
+    c = local_config.fromdictargs(dict(), local_config.invocation_params.args)
     #raise Exception( str(c.getini("filterwarnings")) + " vs " + str(local_config.getini("filterwarnings")))
     s = Session.from_config(c)
-    test_item = Item.from_parent( s, name= f"modulehere_test_{test_mark}")
+    test_item = Item.from_parent(s, name= f"modulehere_test_{test_mark}")
     required = 0
     # add marker with given mark to this test.
-    if isinstance( test_mark, (list,tuple)):
+    if isinstance(test_mark, (list, tuple)):
         for iter_mark in test_mark:
             test_item.add_marker(iter_mark)
         required = len(test_mark)
@@ -24,7 +27,8 @@ def is_enabled(test_mark):
         required = 1
     items = [test_item]
     # pytest/mark modifies items based on supplied args.
-    local_config.hook.pytest_collection_modifyitems(session=s,config=c,items=items)
+    local_config.hook.pytest_collection_modifyitems(
+        session=s, config=c, items=items)
     # if pymark has removed them all of them, that means either positive selections or negative selections
     # have disabled this test
     return len(items) == required

--- a/test/mark_checker.py
+++ b/test/mark_checker.py
@@ -13,15 +13,18 @@ def is_enabled(test_mark):
     #raise Exception( str(c.getini("filterwarnings")) + " vs " + str(local_config.getini("filterwarnings")))
     s = Session.from_config(c)
     test_item = Item.from_parent( s, name= f"modulehere_test_{test_mark}")
+    required = 0
     # add marker with given mark to this test.
     if isinstance( test_mark, (list,tuple)):
         for iter_mark in test_mark:
             test_item.add_marker(iter_mark)
+        required = len(test_mark)
     else:
         test_item.add_marker(test_mark)
+        required = 1
     items = [test_item]
     # pytest/mark modifies items based on supplied args.
     local_config.hook.pytest_collection_modifyitems(session=s,config=c,items=items)
     # if pymark has removed them all of them, that means either positive selections or negative selections
     # have disabled this test
-    return len(items) > 0
+    return len(items) == required

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -2,3 +2,7 @@
 log_format = %(asctime)s %(filename)s:%(lineno)d %(levelname)s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
 pythonpath = .
+markers =
+	slow: slow running test
+	external_network: mark a test using external network
+	remote_credentials: mark a test as requiring kaggle authentication

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -5,4 +5,5 @@ pythonpath = .
 markers =
 	slow: slow running test
 	external_network: mark a test using external network
-	remote_credentials: mark a test as requiring kaggle authentication
+	remote_credentials: mark a test as requiring remote authentication ( that isn't included in checkout )
+	kaggle: uses kaggle

--- a/test/test_Data.py
+++ b/test/test_Data.py
@@ -5,6 +5,7 @@ from aperturedb.Query import QueryBuilder
 import logging
 logger = logging.getLogger(__name__)
 
+
 @pytest.mark.slow
 class TestEntityLoader():
     def assertEqual(self, expected, actual):
@@ -106,6 +107,7 @@ class TestEntityLoader():
             in_csv_file="./input/bboxes-constraints.adb.csv")
         self.assertEqual(3, len(boxes))
         self.assertEqual(1, utils.count_bboxes())
+
 
 @pytest.mark.external_network
 @pytest.mark.remote_credentials

--- a/test/test_Data.py
+++ b/test/test_Data.py
@@ -1,10 +1,11 @@
+import pytest
 import numpy as np
 from aperturedb.Query import QueryBuilder
 
 import logging
 logger = logging.getLogger(__name__)
 
-
+@pytest.mark.slow
 class TestEntityLoader():
     def assertEqual(self, expected, actual):
         if expected != actual:
@@ -106,7 +107,8 @@ class TestEntityLoader():
         self.assertEqual(3, len(boxes))
         self.assertEqual(1, utils.count_bboxes())
 
-
+@pytest.mark.external_network
+@pytest.mark.remote_credentials
 class TestURILoader():
     def assertEqual(self, expected, actual):
         if expected != actual:

--- a/test/test_kaggle.py
+++ b/test/test_kaggle.py
@@ -11,7 +11,8 @@ from unittest.mock import MagicMock, patch
 pytestmark = [pytest.mark.kaggle, pytest.mark.remote_credentials]
 
 if mark_checker.is_enabled(("kaggle", "remote_credentials")):
-    import os
+    global KaggleApi
+    global KaggleData
     from kaggle.api.kaggle_api_extended import KaggleApi
     from aperturedb.KaggleData import KaggleData
 else:

--- a/test/test_kaggle.py
+++ b/test/test_kaggle.py
@@ -1,13 +1,23 @@
+import pytest
+import mark_checker
+
 from collections import namedtuple
 import os
 from typing import List, Tuple
 import zipfile
 import pandas as pd
-import os
-from kaggle.api.kaggle_api_extended import KaggleApi
-from aperturedb.KaggleData import KaggleData
 from unittest.mock import MagicMock, patch
 
+pytestmark = [ pytest.mark.kaggle, pytest.mark.remote_credentials ]
+
+if mark_checker.is_enabled( ("kaggle","remote_credentials") ):
+    import os
+    from kaggle.api.kaggle_api_extended import KaggleApi
+    from aperturedb.KaggleData import KaggleData
+else:
+    # mock class so it will load, we aren't using it.
+    class KaggleData():
+        pass
 kf = namedtuple("files", ["files"])
 file = namedtuple("file", ["fileType", "totalBytes", "name"])
 

--- a/test/test_kaggle.py
+++ b/test/test_kaggle.py
@@ -8,9 +8,9 @@ import zipfile
 import pandas as pd
 from unittest.mock import MagicMock, patch
 
-pytestmark = [ pytest.mark.kaggle, pytest.mark.remote_credentials ]
+pytestmark = [pytest.mark.kaggle, pytest.mark.remote_credentials]
 
-if mark_checker.is_enabled( ("kaggle","remote_credentials") ):
+if mark_checker.is_enabled(("kaggle", "remote_credentials")):
     import os
     from kaggle.api.kaggle_api_extended import KaggleApi
     from aperturedb.KaggleData import KaggleData


### PR DESCRIPTION
- adds mark_checker which allows gating of imports based on what marks are selected
- adds some marks, and decorations
- uses mark_checker to disable kaggle import unless selected as example.