### PR TITLE
Add keepalive

### DIFF
--- a/aperturedb/Configuration.py
+++ b/aperturedb/Configuration.py
@@ -13,6 +13,7 @@ class Configuration:
     name: str
     use_ssl: bool = True
     use_rest: bool = False
+    use_keepalive: bool = True
 
     def __repr__(self) -> str:
         mode = "REST" if self.use_rest else "TCP"

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -239,7 +239,6 @@ class Connector(object):
         if self.use_keepalive:
             keepalive.set(self.conn)
 
-
         # TCP_QUICKACK only supported in Linux 2.4.4+.
         # We use startswith for checking the platform following Python's
         # documentation:

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -36,6 +36,8 @@ import json
 import ssl
 import logging
 
+import keepalive
+
 from threading import Lock
 from types import SimpleNamespace
 from dataclasses import dataclass
@@ -84,12 +86,17 @@ class Connector(object):
         str (password): Password to specify while connecting to the db.
         str (token): Token to use while connecting to the database.
         bool (use_ssl): Use SSL to encrypt communication with the database.
+        bool (use_keepalive): Set keepalive on the connection with the database.  
+            This has two benefits: It reduces the chance of disconnection for a long-running query,
+            and it means that diconnections are detected sooner.
+            Turn this off to reduce traffic on high-cost network connections.
         Configuration (config): Configuration object to use for connection.
     """
 
     def __init__(self, host="localhost", port=55555,
                  user="", password="", token="",
                  use_ssl=True, shared_data=None, authenticate=True,
+                 use_keepalive=True,
                  config: Configuration = None):
         self.connected = False
         self.last_response   = ''
@@ -99,19 +106,22 @@ class Connector(object):
             self.host = host
             self.port = port
             self.use_ssl = use_ssl
+            self.use_keepalive = use_keepalive
             self.config = Configuration(
                 host=self.host,
                 port=self.port,
                 use_ssl=self.use_ssl,
                 username=user,
                 password=password,
-                name="runtime"
+                name="runtime",
+                use_keepalive=use_keepalive
             )
         else:
             self.config = config
             self.host = config.host
             self.port = config.port
             self.use_ssl = config.use_ssl
+            self.use_keepalive = config.use_keepalive
 
         self._connect()
 
@@ -226,6 +236,9 @@ class Connector(object):
 
         self.conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.conn.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
+        if self.use_keepalive:
+            keepalive.set(self.conn)
+
 
         # TCP_QUICKACK only supported in Linux 2.4.4+.
         # We use startswith for checking the platform following Python's

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -86,7 +86,7 @@ class Connector(object):
         str (password): Password to specify while connecting to the db.
         str (token): Token to use while connecting to the database.
         bool (use_ssl): Use SSL to encrypt communication with the database.
-        bool (use_keepalive): Set keepalive on the connection with the database.  
+        bool (use_keepalive): Set keepalive on the connection with the database.
             This has two benefits: It reduces the chance of disconnection for a long-running query,
             and it means that diconnections are detected sooner.
             Turn this off to reduce traffic on high-cost network connections.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ facenet-pytorch
 pytest
 coverage
 protobuf
+keepalive-socket==0.0.1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ install_requires = ['scikit-image', 'image', 'requests', 'boto3',
                     # Pinning this to be able to install google-cloud-bigquery
                     'grpcio-status==1.48.2',
                     # Pinning this to resolve test errors temporarily
-                    'ipywidgets==8.0.4'
+                    'ipywidgets==8.0.4',
+                    'keepalive-socket==0.0.1'
                     ]
 if OPENCV_VERSION is None:
     install_requires.append('opencv-python')


### PR DESCRIPTION
This PR adds (client-side) keepalive to `Connector`.  This uses a small third-party library that claims to work on Linux, MacOS, and Windows.  The new feature is enabled by default.

From my testing, queries longer than about five minutes will be disconnected on AWS (and probably on GCP too).  This problem affects `remove_all_objects`, but would also affect large batch imports.  With this new feature enables, I can keep a query running AWS->AWS for an hour without problems.

This feature does increate network traffic slightly, but the only reason I'm aware of to disable it is if you are accessing aperturedb over a cellular connection.  I am therefore enabling it by default.