### PR TITLE
Re establish connection on errors.

### DIFF
--- a/aperturedb/Configuration.py
+++ b/aperturedb/Configuration.py
@@ -14,10 +14,10 @@ class Configuration:
     use_ssl: bool = True
     use_rest: bool = False
     use_keepalive: bool = True
-    retry_connect_interval_seconds: int = 10
+    retry_connect_interval_seconds: int = 1
     # Max number of attempts to retry the initial connection (0 means infinite)
     # This is useful when the aperturedb server is not ready yet.
-    retry_connect_max_attempts: int = 0
+    retry_connect_max_attempts: int = 3
 
     def __repr__(self) -> str:
         mode = "REST" if self.use_rest else "TCP"

--- a/aperturedb/Configuration.py
+++ b/aperturedb/Configuration.py
@@ -14,6 +14,10 @@ class Configuration:
     use_ssl: bool = True
     use_rest: bool = False
     use_keepalive: bool = True
+    retry_connect_interval_seconds: int = 10
+    # Max number of attempts to retry the initial connection (0 means infinite)
+    # This is useful when the aperturedb server is not ready yet.
+    retry_connect_max_attempts: int = 0
 
     def __repr__(self) -> str:
         mode = "REST" if self.use_rest else "TCP"

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -358,11 +358,15 @@ class Connector(object):
                         response_blob_array = [b for b in querRes.blobs]
                         self.last_response = json.loads(querRes.json)
                         break
-            except ssl.SSLError as e:
+            except ssl.SSLError as ssle:
                 # This can happen in a scenario where multiple
                 # processes might be accessing a single connection.
                 # The copy does not make usable connections.
-                logger.warning(f"Socket error on process {os.getpid()}")
+                logger.exception(ssle)
+                logger.warning(f"SSL error on process {os.getpid()}")
+            except OSError as ose:
+                logger.exception(ose)
+                logger.warning(f"OS error on process {os.getpid()}")
             tries += 1
             logger.warning(
                 f"Connection broken. Reconnectng attempt [{tries}/3] .. PID = {os.getpid()}")

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -97,8 +97,8 @@ class Connector(object):
                  user="", password="", token="",
                  use_ssl=True, shared_data=None, authenticate=True,
                  use_keepalive=True,
-                 retry_connect_interval_seconds=10,
-                 retry_connect_max_attempts=0,
+                 retry_connect_interval_seconds=1,
+                 retry_connect_max_attempts=3,
                  config: Configuration = None):
         self.connected = False
         self.last_response   = ''

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -27,7 +27,6 @@
 from __future__ import annotations
 from . import queryMessage_pb2
 import sys
-import traceback
 import os
 import socket
 import struct
@@ -318,12 +317,7 @@ class Connector(object):
                 self._connect()
             except socket.error as e:
                 logger.error(
-                    f"Error connecting to server: {self.config}. See error log for details.\r\n{details}")
-                logger.warning(
-                    f"Failed to connect to apertureDB server. \r\n{details}.\r\nDetails: \r\n\
-                        {traceback.format_exc()}\r\nat ")
-                logger.warning("Failed to connect",
-                               exc_info=True, stack_info=True)
+                    f"Error connecting to server: {self.config} \r\n{details}.", exc_info=True, stack_info=True)
 
     def _query(self, query, blob_array = [], try_resume=True):
         response_blob_array = []
@@ -416,7 +410,7 @@ class Connector(object):
                 # Hope is that the query send won't be longer than the session
                 # ttl.
                 logger.warning(
-                    f"Session expired while query was sent. Retrying... \r\n{traceback.format_stack(limit=5)}")
+                    f"Session expired while query was sent. Retrying... {self.config}", stack_info=True)
                 self._renew_session()
                 start = time.time()
                 self.response, self.blobs = self._query(q, blobs)
@@ -434,7 +428,7 @@ class Connector(object):
                 break
             except UnauthorizedException as e:
                 logger.warning(
-                    f"[Attempt {count + 1} of 3] Failed to refresh token. Details: \r\n{traceback.format_exc(limit=5)}")
+                    f"[Attempt {count + 1} of 3] Failed to refresh token.", exc_info=True, stack_info=True)
                 time.sleep(1)
                 count += 1
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,13 +31,15 @@ def pytest_generate_tests(metafunc):
                 port = dbinfo.DB_TCP_PORT,
                 user = dbinfo.DB_USER,
                 password = dbinfo.DB_PASSWORD,
-                use_ssl = True)},
+                use_ssl = True,
+                retry_connect_max_attempts=3,
+                retry_connect_interval_seconds=0)},
             {"db": ConnectorRest(
                 host = dbinfo.DB_REST_HOST,
                 port = dbinfo.DB_REST_PORT,
                 user = dbinfo.DB_USER,
                 password = dbinfo.DB_PASSWORD,
-                use_ssl = False
+                use_ssl = False,
             )}
         ], indirect=True, ids=["TCP", "HTTP"])
     if all(func in metafunc.fixturenames for func in ["insert_data_from_csv", "modify_data_from_csv"]) and \

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   aperturedb:
-    image: aperturedata/aperturedb:vdevelop
+    image: aperturedata/aperturedb
     volumes:
       - ./aperturedb/db:/aperturedb/db
       - ./aperturedb/logs:/aperturedb/logs

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   aperturedb:
-    image: aperturedata/aperturedb
+    image: aperturedata/aperturedb:vdevelop
     volumes:
       - ./aperturedb/db:/aperturedb/db
       - ./aperturedb/logs:/aperturedb/logs

--- a/test/run_test_container.sh
+++ b/test/run_test_container.sh
@@ -9,7 +9,7 @@ rm -rf output
 mkdir -m 777 output
 docker compose up -d
 
-LOG_PATH="$(pwd)/aperturedb/log"
+LOG_PATH="$(pwd)/aperturedb/logs"
 TESTING_LOG_PATH="/aperturedb/test/server_logs"
 
 REPOSITORY="aperturedata/aperturedb-python-tests"

--- a/test/run_test_container.sh
+++ b/test/run_test_container.sh
@@ -29,3 +29,10 @@ docker run \
     -e GCP_SERVICE_ACCOUNT_KEY="$GCP_SERVICE_ACCOUNT_KEY" \
     -e APERTUREDB_LOG_PATH="${TESTING_LOG_PATH}" \
     $REPOSITORY
+
+echo "Tests completed"
+echo "aperturedb log:"
+docker compose logs aperturedb
+echo "===================="
+echo "webui test log:"
+docker compose logs webui

--- a/test/test_Session.py
+++ b/test/test_Session.py
@@ -169,7 +169,8 @@ class TestSession():
                 nonlocal count
                 count += 1
                 logger.debug(count)
-                if count < 5:
+                if count < 2:
+                    # Fail for the firs 2 attempts
                     db.conn.close()
 
                 result  = original_send_msg(msg)
@@ -187,7 +188,7 @@ class TestSession():
             }]
             response, blobs = db.query(query)
             assert(response[0]["FindImage"]["status"] == 0)
-            assert count == 6
+            assert count == 3
 
     def test_con_close_on_recv_query(self, db: Connector, monkeypatch):
         if not isinstance(db, ConnectorRest):
@@ -198,8 +199,8 @@ class TestSession():
                 nonlocal count
                 count += 1
                 logger.debug(count)
-                if count < 5:
-                    # Fail for the firs 5 attempts
+                if count < 2:
+                    # Fail for the firs 2 attempts
                     db.conn.close()
 
                 result  = original_recv_msg()
@@ -217,4 +218,4 @@ class TestSession():
             }]
             response, blobs = db.query(query)
             assert(response[0]["FindImage"]["status"] == 0)
-            assert count == 6
+            assert count == 3

--- a/test/test_Session.py
+++ b/test/test_Session.py
@@ -1,23 +1,25 @@
+import socket
 import time
 import logging
 import ssl
+import dbinfo
 
 from aperturedb.Connector import Connector
+from aperturedb.ConnectorRest import ConnectorRest
 
 logger = logging.getLogger(__name__)
 
 
 class TestSession():
-
-    '''
-        These check operation of the Connector Session
-    '''
+    """
+    These check operation of the Connector Session
+    and the error handling with the Network layer
+    """
 
     def test_sessionRenew(self, db: Connector):
-        '''
-            Verifies that Session renew works
-        '''
-
+        """
+        Verifies that Session renew works
+        """
         try:
             # force session token expiry
             db.shared_data.session.session_token_ttl = 1
@@ -46,7 +48,7 @@ class TestSession():
             assert False
 
     def test_SSL_error_on_query(self, db: Connector, monkeypatch):
-        # force session token expiry
+
         original_send_msg = db._send_msg
         count = 0
 
@@ -61,12 +63,13 @@ class TestSession():
             if count == 1:
                 raise ssl.SSLError("SSL Error")
 
-            logger.debug(f"Cut {msg}")
             result  = original_send_msg(msg)
             logger.debug(result)
             return result
 
         monkeypatch.setattr(db, "_send_msg", lambda x: mock_send_msg(x))
+
+        # force session token expiry
         db.shared_data.session.session_token_ttl = 1
         time.sleep(2)
         query = [{
@@ -79,3 +82,139 @@ class TestSession():
         responses, blobs = db.query(query)
         logging.debug(responses)
         assert db.shared_data.session.valid() == True
+
+    def test_socket_connect_error_initial(self, monkeypatch):
+        connect_attempts = 0
+
+        def mock_connect(host, port):
+            nonlocal connect_attempts
+            connect_attempts += 1
+            raise ConnectionRefusedError("Connection Refused")
+        monkeypatch.setattr(socket.socket, "connect",
+                            lambda h, p: mock_connect(h, p))
+
+        # Create new db connection.
+        try:
+            new_db = Connector(
+                dbinfo.DB_TCP_HOST,
+                dbinfo.DB_TCP_PORT,
+                dbinfo.DB_USER,
+                dbinfo.DB_PASSWORD,
+                retry_connect_max_attempts=3,
+                retry_connect_interval_seconds=0)
+        except Exception as e:
+            # Check the exception is not an obscure one.
+            assert str(e).startswith("Could not connect to apertureDB server:")
+
+        # Check that we tried to connect 3 times.
+        assert connect_attempts == 3
+
+    def test_socket_send_error_initial(self, monkeypatch):
+        connect_attempts = 0
+
+        def mock_send(x, buff):
+            nonlocal connect_attempts
+            connect_attempts += 1
+            raise socket.error("Connection broke when send")
+        monkeypatch.setattr(socket.socket, "send", mock_send)
+
+        # Create new db connection.
+        try:
+            new_db = Connector(
+                dbinfo.DB_TCP_HOST,
+                dbinfo.DB_TCP_PORT,
+                dbinfo.DB_USER,
+                dbinfo.DB_PASSWORD,
+                retry_connect_max_attempts=3,
+                retry_connect_interval_seconds=0)
+        except Exception as e:
+            # Check the exception is not an obscure one.
+            assert str(e).startswith("Could not connect to apertureDB server:")
+
+        # Check that we tried to connect 3 times.
+        assert connect_attempts == 3
+
+    def test_socket_recv_error_initial(self, monkeypatch):
+        connect_attempts = 0
+
+        def mock_recv(x, buff):
+            nonlocal connect_attempts
+            connect_attempts += 1
+            # raise socket.error("Connection broke when recv")
+            raise ConnectionResetError("Connection broke when recv")
+        monkeypatch.setattr(socket.socket, "recv", mock_recv)
+
+        # Create new db connection.
+        try:
+            new_db = Connector(
+                dbinfo.DB_TCP_HOST,
+                dbinfo.DB_TCP_PORT,
+                dbinfo.DB_USER,
+                dbinfo.DB_PASSWORD,
+                retry_connect_max_attempts=3,
+                retry_connect_interval_seconds=0)
+        except Exception as e:
+            # Check the exception is not an obscure one.
+            assert str(e).startswith("Could not connect to apertureDB server:")
+
+        # Check that we tried to connect 3 times.
+        assert connect_attempts == 3
+
+    def test_con_close_on_send_query(self, db: Connector, monkeypatch):
+        if not isinstance(db, ConnectorRest):
+            original_send_msg = db._send_msg
+            count = 0
+
+            def mock_send_msg(msg):
+                nonlocal count
+                count += 1
+                logger.debug(count)
+                if count < 5:
+                    db.conn.close()
+
+                result  = original_send_msg(msg)
+                logger.debug(result)
+                return result
+
+            monkeypatch.setattr(db, "_send_msg", mock_send_msg)
+
+            query = [{
+                "FindImage": {
+                    "results": {
+                        "limit": 5
+                    }
+                }
+            }]
+            response, blobs = db.query(query)
+            assert(response[0]["FindImage"]["status"] == 0)
+            assert count == 6
+
+    def test_con_close_on_recv_query(self, db: Connector, monkeypatch):
+        if not isinstance(db, ConnectorRest):
+            original_recv_msg = db._recv_msg
+            count = 0
+
+            def mock_recv_msg():
+                nonlocal count
+                count += 1
+                logger.debug(count)
+                if count < 5:
+                    # Fail for the firs 5 attempts
+                    db.conn.close()
+
+                result  = original_recv_msg()
+                logger.debug(result)
+                return result
+
+            monkeypatch.setattr(db, "_recv_msg", mock_recv_msg)
+
+            query = [{
+                "FindImage": {
+                    "results": {
+                        "limit": 5
+                    }
+                }
+            }]
+            response, blobs = db.query(query)
+            assert(response[0]["FindImage"]["status"] == 0)
+            assert count == 6


### PR DESCRIPTION
This would handle scenarios where a long running connection would be checked for errors, with logic to recover.
Reported as in #258 