### PR TITLE
Internal ref ids start at 10000

### DIFF
--- a/aperturedb/BBoxDataCSV.py
+++ b/aperturedb/BBoxDataCSV.py
@@ -83,7 +83,7 @@ class BBoxDataCSV(CSVParser.CSVParser):
 
         img_id = self.df.loc[idx, self.img_key]
 
-        img_ref = (idx % 10000) + 1
+        img_ref = (idx % 99998) + 1
 
         fi = {
             "FindImage": {

--- a/aperturedb/ConnectionDataCSV.py
+++ b/aperturedb/ConnectionDataCSV.py
@@ -85,7 +85,7 @@ class ConnectionDataCSV(CSVParser):
         members = ["_Image", "_Blob", "_Video", "_Descriptor"]
 
         try:
-            ref_src = (2 * idx) % 100000 + 1
+            ref_src = (2 * idx) % 99998 + 1
             cmd_params = {
                 "_ref": ref_src,
                 "unique": True,

--- a/aperturedb/PolygonDataCSV.py
+++ b/aperturedb/PolygonDataCSV.py
@@ -84,7 +84,7 @@ class PolygonDataCSV(CSVParser.CSVParser):
 
         img_id = self.df.loc[idx, self.img_key]
 
-        img_ref = (idx % 10000) + 1
+        img_ref = (idx % 99998) + 1
         fi = {
             "FindImage": {
                 "_ref": img_ref,


### PR DESCRIPTION
The aperturedb API permits refs to be in the range [1,100000), and uses higher numbers for internal purposes.  Because of a recent change in the aperturedb API, we are now enforcing this restriction, whereas previously violations were quietly ignored.  The CSV loader wants to avoid ref collision when batching, so assigns refs serially, modulo a limit.  Because these refs are sometimes assigned in pairs, we were going over this limit.  This change ensures we stay under the limit.

Note that there is still an outstanding problem because the CSV loader is merely hoping that this modulo trick is sufficient to ensure that batches are semantically coherent.  A better approach might be to have the batching process itself remap ref numbers on the fly.