### PR TITLE
Feature/lazy connector

### DIFF
--- a/aperturedb/Configuration.py
+++ b/aperturedb/Configuration.py
@@ -14,10 +14,10 @@ class Configuration:
     use_ssl: bool = True
     use_rest: bool = False
     use_keepalive: bool = True
-    retry_connect_interval_seconds: int = 1
+    retry_interval_seconds: int = 1
     # Max number of attempts to retry the initial connection (0 means infinite)
     # This is useful when the aperturedb server is not ready yet.
-    retry_connect_max_attempts: int = 3
+    retry_max_attempts: int = 3
 
     def __repr__(self) -> str:
         mode = "REST" if self.use_rest else "TCP"

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -438,7 +438,7 @@ class Connector(object):
                 # Hope is that the query send won't be longer than the session
                 # ttl.
                 logger.warning(
-                    f"Session expired while query was sent. Retrying... {self.config}", stack_info=True)
+                    f"Session expired while query was sent. Retrying... {self.config}")
                 self._renew_session()
                 start = time.time()
                 self.response, self.blobs = self._query(q, blobs)

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -384,7 +384,7 @@ class Connector(object):
 
             tries += 1
             logger.warning(
-                f"Connection broken. Reconnectng attempt [{tries}/{self.config.retry_max_attempts}] .. PID = {os.getpid()}")
+                f"Connection broken. Reconnecting attempt [{tries}/{self.config.retry_max_attempts}] .. PID = {os.getpid()}")
 
             if self.connected:
                 self.conn.close()

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -378,6 +378,7 @@ class Connector(object):
             except AttributeError as ae:
                 if self.connected:
                     # Only log if we got this while connected.
+                    # else it is expected after unification of query/connect
                     logger.exception(ae)
                     logger.warning(f"Attribute error on process {os.getpid()}")
 
@@ -420,12 +421,12 @@ class Connector(object):
         Returns:
             _type_: _description_
         """
-
-        self.authenticate(
-            shared_data=self.shared_data,
-            user=self.config.username,
-            password=self.config.password,
-            token=self.token)
+        if self.should_authenticate:
+            self.authenticate(
+                shared_data=self.shared_data,
+                user=self.config.username,
+                password=self.config.password,
+                token=self.token)
 
         try:
             start = time.time()

--- a/aperturedb/ConnectorRest.py
+++ b/aperturedb/ConnectorRest.py
@@ -109,7 +109,7 @@ class ConnectorRest(Connector):
         tries = 0
         response = SimpleNamespace()
         response.status_code = 0
-        while tries < 3:
+        while tries < self.config.retry_max_attempts:
             tries += 1
             response = self.http_session.post(self.url,
                                               headers = headers,
@@ -126,7 +126,8 @@ class ConnectorRest(Connector):
             logger.error(
                 f"Response not OK = {response.status_code} {response.text[:1000]}\n\
                     attempt [{tries}/3] .. PID = {os.getpid()}")
-            time.sleep(1)
+
+            time.sleep(self.config.retry_interval_seconds)
 
         if tries == 3:
             raise Exception(

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -85,16 +85,13 @@ class Utils(object):
     """
 
     def __init__(self, connector: Connector, verbose=False):
-
         self.connector = connector.create_new_connection()
         self.verbose = verbose
 
     def __repr__(self):
-
         return self.status()
 
     def print(self, str):
-
         if self.verbose:
             print(str)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -32,8 +32,8 @@ def pytest_generate_tests(metafunc):
                 user = dbinfo.DB_USER,
                 password = dbinfo.DB_PASSWORD,
                 use_ssl = True,
-                retry_connect_max_attempts=3,
-                retry_connect_interval_seconds=0)},
+                retry_max_attempts=3,
+                retry_interval_seconds=0)},
             {"db": ConnectorRest(
                 host = dbinfo.DB_REST_HOST,
                 port = dbinfo.DB_REST_PORT,

--- a/test/test_Data.py
+++ b/test/test_Data.py
@@ -6,6 +6,7 @@ from aperturedb.Query import QueryBuilder, Query
 from aperturedb.Entities import Entities
 from aperturedb.Constraints import Constraints
 from aperturedb.Images import Images
+from aperturedb.Utils import Utils
 
 import logging
 logger = logging.getLogger(__name__)
@@ -22,7 +23,7 @@ class TestEntityLoader():
         if not condition:
             raise AssertionError("Condition not true")
 
-    def test_Loader(self, utils, insert_data_from_csv):
+    def test_Loader(self, utils: Utils, insert_data_from_csv):
         classes = ["_Image", "_Descriptor", "Person", "_BoundingBox"]
         self.assertTrue(utils.remove_all_indexes())
         self.assertTrue(utils.remove_all_objects())

--- a/test/test_Server.py
+++ b/test/test_Server.py
@@ -18,11 +18,18 @@ class TestBadResponses():
         monkeypatch.setattr(Connector, "_query", failed_auth_query)
 
         with pytest.raises(Exception) as conn_exception:
-            Connector(
+            db = Connector(
                 host = dbinfo.DB_TCP_HOST,
                 port = dbinfo.DB_TCP_PORT,
                 user = dbinfo.DB_USER,
                 password = dbinfo.DB_PASSWORD,
                 use_ssl = True)
+            db.query([{
+                "FindImage": {
+                    "results": {
+                        "limit": 5
+                    }
+                }
+            }])
 
         assert "Unexpected response" in str(conn_exception.value)

--- a/test/test_Session.py
+++ b/test/test_Session.py
@@ -20,32 +20,29 @@ class TestSession():
         """
         Verifies that Session renew works
         """
-        try:
-            # force session token expiry
-            db.shared_data.session.session_token_ttl = 1
-            logging.debug("Connected? {0}".format(
-                "yes" if db.connected else "no"))
 
-            logging.debug(
-                "Session valid? {0}".format(
-                    "yes" if db.shared_data.session.valid() else "no"))
-            logging.debug("Valid length: {0}".format(
-                db.shared_data.session.session_token_ttl))
-            time.sleep(2)
-            query = [{
-                "FindImage": {
-                    "results": {
-                        "limit": 5
-                    }
+        # force session token expiry
+        db.shared_data.session.session_token_ttl = 1
+        logger.debug("Connected? {0}".format(
+            "yes" if db.connected else "no"))
+        logger.debug(
+            "Session valid? {0}".format(
+                "yes" if db.shared_data.session.valid() else "no"))
+        logger.debug("Valid length: {0}".format(
+            db.shared_data.session.session_token_ttl))
+        time.sleep(2)
+        query = [{
+            "FindImage": {
+                "results": {
+                    "limit": 5
                 }
-            }]
-            responses, blobs = db.query(query)
-            logging.debug(responses)
-            assert db.shared_data.session.valid() == True
-        except Exception as e:
-            print(e)
-            print("Failed to renew Session")
-            assert False
+            }
+        }]
+        responses, blobs = db.query(query)
+        logger.debug(responses)
+        logger.debug("Valid : {0}".format(
+            db.shared_data.session.valid()))
+        assert db.shared_data.session.valid() == True
 
     def test_SSL_error_on_query(self, db: Connector, monkeypatch):
 
@@ -100,8 +97,8 @@ class TestSession():
                 dbinfo.DB_TCP_PORT,
                 dbinfo.DB_USER,
                 dbinfo.DB_PASSWORD,
-                retry_connect_max_attempts=3,
-                retry_connect_interval_seconds=0)
+                retry_max_attempts=3,
+                retry_interval_seconds=0)
         except Exception as e:
             # Check the exception is not an obscure one.
             assert str(e).startswith("Could not connect to apertureDB server:")
@@ -125,8 +122,8 @@ class TestSession():
                 dbinfo.DB_TCP_PORT,
                 dbinfo.DB_USER,
                 dbinfo.DB_PASSWORD,
-                retry_connect_max_attempts=3,
-                retry_connect_interval_seconds=0)
+                retry_max_attempts=3,
+                retry_interval_seconds=0)
         except Exception as e:
             # Check the exception is not an obscure one.
             assert str(e).startswith("Could not connect to apertureDB server:")
@@ -151,8 +148,8 @@ class TestSession():
                 dbinfo.DB_TCP_PORT,
                 dbinfo.DB_USER,
                 dbinfo.DB_PASSWORD,
-                retry_connect_max_attempts=3,
-                retry_connect_interval_seconds=0)
+                retry_max_attempts=3,
+                retry_interval_seconds=0)
         except Exception as e:
             # Check the exception is not an obscure one.
             assert str(e).startswith("Could not connect to apertureDB server:")

--- a/test/test_Session.py
+++ b/test/test_Session.py
@@ -44,8 +44,15 @@ class TestSession():
             db.shared_data.session.valid()))
         assert db.shared_data.session.valid() == True
 
-    def test_SSL_error_on_query(self, db: Connector, monkeypatch):
-
+    def test_SSL_error_on_query(self, monkeypatch):
+        db = Connector(
+            dbinfo.DB_TCP_HOST,
+            dbinfo.DB_TCP_PORT,
+            dbinfo.DB_USER,
+            dbinfo.DB_PASSWORD,
+            retry_max_attempts=3,
+            retry_interval_seconds=0)
+        db.query([{"FindImage": {"results": {"limit": 5}}}])
         original_send_msg = db._send_msg
         count = 0
 
@@ -91,17 +98,19 @@ class TestSession():
                             lambda h, p: mock_connect(h, p))
 
         # Create new db connection.
+
+        new_db = Connector(
+            dbinfo.DB_TCP_HOST,
+            dbinfo.DB_TCP_PORT,
+            dbinfo.DB_USER,
+            dbinfo.DB_PASSWORD,
+            retry_max_attempts=3,
+            retry_interval_seconds=0)
         try:
-            new_db = Connector(
-                dbinfo.DB_TCP_HOST,
-                dbinfo.DB_TCP_PORT,
-                dbinfo.DB_USER,
-                dbinfo.DB_PASSWORD,
-                retry_max_attempts=3,
-                retry_interval_seconds=0)
+            new_db.query([{"FindImage": {"results": {"limit": 5}}}])
         except Exception as e:
             # Check the exception is not an obscure one.
-            assert str(e).startswith("Could not connect to apertureDB server:")
+            assert e.args[0] == "Authentication failed:"
 
         # Check that we tried to connect 3 times.
         assert connect_attempts == 3
@@ -116,17 +125,18 @@ class TestSession():
         monkeypatch.setattr(socket.socket, "send", mock_send)
 
         # Create new db connection.
+        new_db = Connector(
+            dbinfo.DB_TCP_HOST,
+            dbinfo.DB_TCP_PORT,
+            dbinfo.DB_USER,
+            dbinfo.DB_PASSWORD,
+            retry_max_attempts=3,
+            retry_interval_seconds=0)
         try:
-            new_db = Connector(
-                dbinfo.DB_TCP_HOST,
-                dbinfo.DB_TCP_PORT,
-                dbinfo.DB_USER,
-                dbinfo.DB_PASSWORD,
-                retry_max_attempts=3,
-                retry_interval_seconds=0)
+            new_db.query([{"FindImage": {"results": {"limit": 5}}}])
         except Exception as e:
             # Check the exception is not an obscure one.
-            assert str(e).startswith("Could not connect to apertureDB server:")
+            assert e.args[0] == "Authentication failed:"
 
         # Check that we tried to connect 3 times.
         assert connect_attempts == 3
@@ -142,17 +152,19 @@ class TestSession():
         monkeypatch.setattr(socket.socket, "recv", mock_recv)
 
         # Create new db connection.
+
+        new_db = Connector(
+            dbinfo.DB_TCP_HOST,
+            dbinfo.DB_TCP_PORT,
+            dbinfo.DB_USER,
+            dbinfo.DB_PASSWORD,
+            retry_max_attempts=3,
+            retry_interval_seconds=0)
         try:
-            new_db = Connector(
-                dbinfo.DB_TCP_HOST,
-                dbinfo.DB_TCP_PORT,
-                dbinfo.DB_USER,
-                dbinfo.DB_PASSWORD,
-                retry_max_attempts=3,
-                retry_interval_seconds=0)
+            new_db.query([{"FindImage": {"results": {"limit": 5}}}])
         except Exception as e:
             # Check the exception is not an obscure one.
-            assert str(e).startswith("Could not connect to apertureDB server:")
+            assert e.args[0] == "Authentication failed:"
 
         # Check that we tried to connect 3 times.
         assert connect_attempts == 3

--- a/test/test_Session.py
+++ b/test/test_Session.py
@@ -116,11 +116,11 @@ class TestSession():
         assert connect_attempts == 3
 
     def test_socket_send_error_initial(self, monkeypatch):
-        connect_attempts = 0
+        send_attempts = 0
 
         def mock_send(x, buff):
-            nonlocal connect_attempts
-            connect_attempts += 1
+            nonlocal send_attempts
+            send_attempts += 1
             raise socket.error("Connection broke when send")
         monkeypatch.setattr(socket.socket, "send", mock_send)
 
@@ -138,8 +138,8 @@ class TestSession():
             # Check the exception is not an obscure one.
             assert e.args[0] == "Authentication failed:"
 
-        # Check that we tried to connect 3 times.
-        assert connect_attempts == 3
+        # Check that we tried to send 5 (connect hello:2) + query:3) times.
+        assert send_attempts == 5
 
     def test_socket_recv_error_initial(self, monkeypatch):
         connect_attempts = 0


### PR DESCRIPTION
Shifts the connect activity of the connector from init to the first query time.
This would allow connectors to be created without exceptions for the cases where client is up before a server.

test session needs to be triple checked for correctness as lot of initial assumptions of how authentication and session renewal is changed.

This also aligns the query behavior of connectorrest to that of connector. They were implemented with subtle differences 


Fix #258 