### PR TITLE
Fix for response_handler

### DIFF
--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def execute_batch(q, blobs, db, success_statuses: list[int] = [0],
-                  response_handler: Callable = None, commands_per_query: int = 1, blobs_per_query: int = 1,
+                  response_handler: Callable = None, commands_per_query: int = 1, blobs_per_query: int = 0,
                   strict_response_validation: bool = False):
     """
     Execute a batch of queries, doing useful logging around it.

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -28,9 +28,9 @@ def execute_batch(q, blobs, db, success_statuses: list[int] = [0],
         - 2 : For any other code.
     """
     result = 0
-    # logger.debug(f"Query={q}")
+    logger.debug(f"Query={q}")
     r, b = db.query(q, blobs)
-    # logger.debug(f"Response={r}")
+    logger.debug(f"Response={r}")
 
     if db.last_query_ok():
         if response_handler is not None:

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -58,12 +58,13 @@ def execute_batch(q, blobs, db, success_statuses: list[int] = [0],
                             b_count += count
 
                 try:
+                    # The returned blobs need to be sliced to match the
+                    # returned entities per command in query.
                     response_handler(
                         q[start:end],
                         blobs[blobs_start:blobs_end],
                         r[start:end],
-                        b)
-                    # b[blobs_returned:blobs_returned + b_count] if len(b) < blobs_returned + b_count else None)
+                        b[blobs_returned:blobs_returned + b_count] if len(b) >= blobs_returned + b_count else None)
                 except BaseException as e:
                     logger.exception(e)
                     if strict_response_validation:

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -48,7 +48,7 @@ def execute_batch(q, blobs, db, success_statuses: list[int] = [0],
                     for k in req:
                         # Ref to https://docs.aperturedata.io/query_language/Reference/shared_command_parameters/blobs
                         blobs_where_default_true = \
-                            k in ["FindImage", "FindBlob"] and (
+                            k in ["FindImage", "FindBlob", "FindVideo"] and (
                                 "blobs" not in req[k] or req[k]["blobs"])
                         blobs_where_default_false = \
                             k in [

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def execute_batch(q, blobs, db, success_statuses: list[int] = [0],
-                  response_handler: Callable = None, commands_per_query: int = 1, blobs_per_query: int = 0,
+                  response_handler: Callable = None, commands_per_query: int = 1, blobs_per_query: int = 1,
                   strict_response_validation: bool = False):
     """
     Execute a batch of queries, doing useful logging around it.
@@ -28,9 +28,9 @@ def execute_batch(q, blobs, db, success_statuses: list[int] = [0],
         - 2 : For any other code.
     """
     result = 0
-    logger.debug(f"Query={q}")
+    # logger.debug(f"Query={q}")
     r, b = db.query(q, blobs)
-    logger.debug(f"Response={r}")
+    # logger.debug(f"Response={r}")
 
     if db.last_query_ok():
         if response_handler is not None:
@@ -62,7 +62,8 @@ def execute_batch(q, blobs, db, success_statuses: list[int] = [0],
                         q[start:end],
                         blobs[blobs_start:blobs_end],
                         r[start:end],
-                        b[blobs_returned:blobs_returned + b_count] if len(b) < blobs_returned + b_count else None)
+                        b)
+                    # b[blobs_returned:blobs_returned + b_count] if len(b) < blobs_returned + b_count else None)
                 except BaseException as e:
                     logger.exception(e)
                     if strict_response_validation:

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -5,6 +5,7 @@ from aperturedb.EntityDataCSV import EntityDataCSV
 from aperturedb.ParallelLoader import ParallelLoader
 from aperturedb.ParallelQuery import ParallelQuery
 from aperturedb.Subscriptable import Subscriptable
+from aperturedb.Connector import Connector
 import math
 
 logger = logging.getLogger(__name__)
@@ -51,10 +52,11 @@ class GeneratorWithNCommands(Subscriptable):
 
 
 class QGPersons(Subscriptable):
-    def __init__(self, requests, responses, cpq) -> None:
+    def __init__(self, requests, responses, cpq, response_blobs) -> None:
         super().__init__()
         self.requests = requests
         self.responses = responses
+        self.response_blobs = response_blobs
         self.cpq = cpq
 
     def __len__(self):
@@ -83,18 +85,60 @@ class QGPersons(Subscriptable):
     def response_handler(self, request, input_blob, response, output_blob):
         self.requests.append(request)
         self.responses.append(response)
+        if output_blob is not None and len(output_blob) > 0:
+            self.response_blobs.append(output_blob)
+
+
+class QGImages(QGPersons):
+    def getitem(self, subscript):
+        query = []
+        for i in range(self.cpq):
+            q = {
+                "FindImage": {
+
+                }
+            }
+            query.append(q)
+        return query, []
+
+
+# Fake DB query.
+def mock_query(self, request, blobs):
+    self.response = 0
+    return [], []
+
+# Fake DB query. Depending in the transaction, return a response increasing number of images.
+# Also add a item (int) to the blobs list for each image returned (to simulate the image data)
+# The number of blobs returned is validated at the end.
+
+
+def query_mocker_factory(response_blobs_count):
+    def mock_query(self, request, blobs):
+        self.response = 0
+        mock_responses = [{
+            "FindImage": {
+                "returned": (i + 1),
+                "status": 0
+            }
+        } for i, c in enumerate(request)]
+        mock_blobs = [i for i in range(
+            int(response_blobs_count * len(request)))]
+        return mock_responses, mock_blobs
+    return mock_query
 
 
 class TestResponseHandler():
     def cleanDB(self, utils):
         logger.debug(f"Cleaning existing data")
-        assert utils.remove_all_indexes()
-        assert utils.remove_all_objects() == True
+        # assert utils.remove_all_indexes()
+        # assert utils.remove_all_objects() == True
         self.requests = []
         self.responses = []
 
     @pytest.mark.parametrize("records_count", [(1), (99), (100)])
-    def test_response_handler(self, records_count, db, utils):
+    def test_response_handler(self, records_count, db, utils, monkeypatch):
+        monkeypatch.setattr(Connector, "query", lambda s,
+                            r, b: mock_query(s, r, b))
         self.cleanDB(utils=utils)
         logger.warning(f"{records_count}")
         persons = EntityWithResponseDataCSV(
@@ -113,7 +157,9 @@ class TestResponseHandler():
         assert len(self.requests) == records_count
 
     @pytest.mark.parametrize("commands_blobs", combinations(range(1, 4), 2))
-    def test_varying_commands_blobs(self, db, commands_blobs):
+    def test_varying_commands_blobs(self, db, commands_blobs, monkeypatch):
+        monkeypatch.setattr(Connector, "query", lambda s,
+                            r, b: mock_query(s, r, b))
         i, j  = commands_blobs
         generator = GeneratorWithNCommands(i, j)
         querier = ParallelQuery(db, dry_run=True)
@@ -139,7 +185,9 @@ class TestResponseHandler():
 
         self.requests = []
         self.responses = []
-        generator = QGPersons(self.requests, self.responses, cpq)
+        self.response_blobs = []
+        generator = QGPersons(self.requests, self.responses,
+                              cpq, self.response_blobs)
         querier = ParallelQuery(db)
         querier.query(generator, batchsize=100,
                       numthreads=1,
@@ -156,3 +204,21 @@ class TestResponseHandler():
         logger.debug(dist_by_ages)
         for k in dist_by_ages:
             assert dist_by_ages[k] == dist["age"][k]
+
+    def test_response_blobs(self, db, utils, monkeypatch):
+        monkeypatch.setattr(Connector, "query", lambda s, r,
+                            b: query_mocker_factory(5.5)(s, r, b))
+        self.cleanDB(utils=utils)
+        self.response_blobs = []
+        generator = QGImages(self.requests, self.responses,
+                             1, self.response_blobs)
+        querier = ParallelQuery(db)
+        querier.query(generator, batchsize=99,
+                      numthreads=31,
+                      stats=True)
+        assert len(self.response_blobs) == len(self.responses)
+        for i, resp in enumerate(self.responses):
+            for key in resp[0]:
+                assert resp[0][key]["returned"] == i + 1
+                assert resp[0][key]["status"] == 0
+                assert len(self.response_blobs[i]) == resp[0][key]["returned"]

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -130,8 +130,6 @@ def query_mocker_factory(response_blobs_count):
 class TestResponseHandler():
     def cleanDB(self, utils):
         logger.debug(f"Cleaning existing data")
-        # assert utils.remove_all_indexes()
-        # assert utils.remove_all_objects() == True
         self.requests = []
         self.responses = []
 


### PR DESCRIPTION
Currently, response_handler is not being passed the right blobs corresponding to the response. This Branch has a workaround that will pass the right blobs under the special condition that we have BATCH_SIZE=1, but there is a need for a more general fix. 

This branch is needed for `nsfw_detector` to work: https://github.com/aperture-data/demos/pull/148