### PR TITLE
docker notebook should use the latest dependencies.

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -126,6 +126,7 @@ build_notebook_dependencies_image(){
         # Build will use cache to speed up the process
         # Runs from github events
         cache_control="--cache-from ${DEPS_IMAGE}"
+        docker pull ${DEPS_IMAGE}
     else
         # Build won't use cache to create a fresh image
         # Runs from cron-job


### PR DESCRIPTION
Despite the fact that we build and push the docker image every night, an older version of [cached dependencies](https://github.com/aperture-data/aperturedb-python/actions/runs/7939158216/job/21678899491) was being used to build aperturedb-notebook.