### PR TITLE
First pass at schema visualization

### DIFF
--- a/aperturedb/cli/utilities.py
+++ b/aperturedb/cli/utilities.py
@@ -62,3 +62,22 @@ def log(
     """
     utils = Utils(create_connector())
     utils.user_log_message(message, level=level.value)
+
+
+@app.command()
+def visualize_schema(
+    filename: str = "schema",
+    format: str = "png"
+):
+    """
+    Visualize the schema of the database.
+
+    This will create a file with the schema of the database in the specified format.
+
+    Relies on graphviz to be installed.
+    """
+
+    utils = Utils(create_connector())
+    s = utils.visualize_schema()
+    result = s.render(filename, format=format)
+    print(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     'grpcio-status==1.48.2',
     # Pinning this to resolve test errors temporarily
     'ipywidgets==8.0.4',
-    'keepalive-socket==0.0.1'
+    'keepalive-socket==0.0.1',
+    'graphviz==0.20.2'
 ]
 
 [tool.setuptools.package-dir]


### PR DESCRIPTION
This adds a `visualize_schema` method to `Utils` and a corresponding `visualize-schema` command to the CLI.

Simply call
```
adb utils visualize-schema
```
or 
```
adb utils visualize-schema --filename=schema --format=png
```

Relies on graphviz installation.
<img width="1392" alt="schema" src="https://github.com/aperture-data/aperturedb-python/assets/31326650/2fff3aac-3ee9-4a54-a296-0ea47750081f">
