### PR TITLE
Do not assume an subscriptable of errors when commands fail at aperturedb

### DIFF
--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -276,7 +276,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 for i in range(0, len(r), self.commands_per_query):
                     # Some errors stop the whole query from being executed
                     # https://docs.aperturedata.io/query_language/Overview/Responses#return-status
-                    if isinstance(type(r), list):
+                    if issubclass(type(r), list):
                         if all([v['status'] == 0 for j in r[i:i + self.commands_per_query] for k, v in filter_per_group(j)]):
                             sq += 1
                 worker_stats["succeeded_queries"] = sq

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -274,8 +274,11 @@ class ParallelQuery(Parallelizer.Parallelizer):
                     [v['status'] == 2 for i in r for k, v in filter_per_group(i)])
                 sq = 0
                 for i in range(0, len(r), self.commands_per_query):
-                    if all([v['status'] == 0 for j in r[i:i + self.commands_per_query] for k, v in filter_per_group(j)]):
-                        sq += 1
+                    # Some errors stop the whole query from being executed
+                    # https://docs.aperturedata.io/query_language/Overview/Responses#return-status
+                    if isinstance(type(r), list):
+                        if all([v['status'] == 0 for j in r[i:i + self.commands_per_query] for k, v in filter_per_group(j)]):
+                            sq += 1
                 worker_stats["succeeded_queries"] = sq
         else:
             query_time = 1

--- a/aperturedb/cli/ingest.py
+++ b/aperturedb/cli/ingest.py
@@ -218,7 +218,6 @@ def from_csv(filepath: Annotated[str, typer.Argument(
     else:
         loader.ingest(data, batchsize=batchsize,
                       numthreads=num_workers, stats=stats)
-        console.log(loader.actual_stats)
 
 
 @app.command()

--- a/aperturedb/cli/ingest.py
+++ b/aperturedb/cli/ingest.py
@@ -218,6 +218,7 @@ def from_csv(filepath: Annotated[str, typer.Argument(
     else:
         loader.ingest(data, batchsize=batchsize,
                       numthreads=num_workers, stats=stats)
+        console.log(loader.actual_stats)
 
 
 @app.command()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -65,10 +65,13 @@ def db(request):
 
 
 def check_response_regressions(queries, input_blobs, responses, output_blobs):
-    # Check that responses have no blobs
-    first_command = list(responses[0].keys())[0]
-    assert "blobs_start" not in responses[0][
-        first_command], f"responses[0]={responses[0]}"
+    if issubclass(type(responses), list):
+        # Check that responses have no blobs
+        first_command = list(responses[0].keys())[0]
+        assert "blobs_start" not in responses[0][
+            first_command], f"{responses[0]=}"
+    else:
+        assert responses["status"] in [-1, 3],  f"{responses=}"
 
 
 @pytest.fixture()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,7 +20,7 @@ from aperturedb.Utils import Utils
 import dbinfo
 
 # These are test fixtures and can be used in any
-# pytest tests as function parmeters with same names.
+# pytest tests as function parameters with same names.
 
 
 def pytest_generate_tests(metafunc):
@@ -135,15 +135,11 @@ def insert_data_from_csv(db, request):
             loader.get_succeeded_queries() == expected_error_count
         if loader_result_lambda is not None:
             loader_result_lambda(loader, data)
-        assert len(data) - \
-            loader.get_succeeded_queries() == expected_error_count
-        if loader_result_lambda is not None:
-            loader_result_lambda(loader, data)
 
         # Preserve loader so that dask manager is not auto deleted.
         # ---------------
         # Previously, dask's cluster and client were entirely managed in a context
-        # insede dask manager. A change upstream broke that, and now we keep the DM
+        # inside dask manager. A change upstream broke that, and now we keep the DM
         # in scope just so that we can do computations after ingestion, as those
         # things are lazily evaluated.
         return data, loader


### PR DESCRIPTION
This used to result in errors on the line of :
unhashable type: 'slice', which was not a useful (underlying) bit to be shown to the user.

For example, with a return code 3, the query or transaction does not return a list which was the earlier expectation in calculating the actual stats.