### PR TITLE
Included segmentation info when ingesting coco annotations.

### DIFF
--- a/examples/CocoDataPyTorch.py
+++ b/examples/CocoDataPyTorch.py
@@ -1,6 +1,24 @@
 from aperturedb.PyTorchData import PyTorchData
 from torchvision.datasets import CocoDetection
-from aperturedb.Images import image_to_byte_array
+from aperturedb.Images import image_to_bytes
+import pycocotools.mask as mask
+import cv2
+
+
+def polygonFromMask(maskedArr):
+    # adapted from https://github.com/hazirbas/coco-json-converter/blob/master/generate_coco_json.py
+    contours, _ = cv2.findContours(
+        maskedArr, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+    segmentation = []
+    valid_poly = 0
+    for contour in contours:
+        # Valid polygons have >= 6 coordinates (3 points)
+        if contour.size >= 6:
+            segmentation.append(contour.astype(float).flatten().tolist())
+            valid_poly += 1
+    if valid_poly == 0:
+        raise ValueError
+    return segmentation
 
 
 class CocoDataPyTorch(PyTorchData):
@@ -16,38 +34,74 @@ class CocoDataPyTorch(PyTorchData):
         area, bbox, category_id, image_id, id, iscrowd, keypoints, num_keypoints, segmentation
         """
         coco_detection = CocoDetection(
-            root="coco/val2017",
-            annFile="coco/annotations/person_keypoints_val2017.json")
+            root="/mnt/data/datasets/coco/data/images/val2017/",
+            annFile="/mnt/data/datasets/coco/data/annotations/stuff_val2017.json")
+        self.coco_detection = coco_detection
         super().__init__(coco_detection)
 
     def generate_query(self, idx: int):
         item = self.loaded_dataset[idx]
         q = [{
             "AddImage": {
-                "_ref": 1
+                "_ref": 2
             }
         }]
-        blob = image_to_byte_array(item[0])
+        blob = image_to_bytes(item[0])
         if len(item[1]) > 0:
             meta_info = item[1][0]
+            category_id = meta_info["category_id"]
+            category_info = self.coco_detection.coco.loadCats(category_id)[0]
+
             q[0]["AddImage"]["properties"] = {
                 # Hack: Concatenate the list types as aperturedb does not support arrays for properties yet.
                 p: " ".join(map(str, meta_info[p])) if isinstance(meta_info[p], list) else meta_info[p] for p in meta_info
             }
+
+            q.insert(0, {
+                "AddEntity": {
+                    "_ref": 1,
+                    "class": "SuperCategory",
+                    "properties": {
+                        "name": category_info["supercategory"]
+                    }
+                }
+            })
+
             # If bounding box is present, make an aperturedb object connected to the image
             if "bbox" in meta_info:
                 bbox = meta_info["bbox"]
                 q.append({
                     "AddBoundingBox": {
-                        "image_ref": 1,
+                        "image_ref": 2,
                         "rectangle": {
                             "x": int(bbox[0]),
                             "y": int(bbox[1]),
                             "width": int(bbox[2]),
                             "height": int(bbox[3])
                         },
-                        "label": str(meta_info["category_id"])
+                        "label": str(category_info["name"])
                     }
                 })
+
+            if "segmentation" in meta_info:
+                segmentation = meta_info["segmentation"]
+                # Convert RLE to polygons in adb
+                # https://github.com/cocodataset/cocoapi/issues/476
+                m = mask.decode(segmentation)
+                polygons = polygonFromMask(m)
+                adb_polygons = []
+                for polygon in polygons:
+                    adb_polygon = []
+                    for i in range(0, len(polygon), 2):
+                        adb_polygon.append([polygon[i], polygon[i + 1]])
+                    adb_polygons.append(adb_polygon)
+                for adb_polygon in adb_polygons:
+                    q.append({
+                        "AddPolygon": {
+                            "image_ref": 2,
+                            "label": str(category_info["name"]),
+                            "polygons": [adb_polygon]
+                        }
+                    })
 
         return q, [blob]


### PR DESCRIPTION
Ingestion command:

`adb ingest from-generator examples/CocoDataPyTorch.py  --sample-count 1 --transformer image_properties`

View the image(s) :

```
q=[
  {
    "FindImage": {
      "blobs": True,
      "uniqueids": True,
      "unique": False,
      "results": {
        "limit": 5,
        "all_properties": True
      }
    }
  }
]

r, blobs = db.query(q, [])
# print(r)

imgs = Images(db, response=r[0]["FindImage"]["entities"])
imgs.display(show_polygons=True, show_bboxes=True)
```