### PR TITLE
Add response handler support to ParallelQuerySet

### DIFF
--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -126,14 +126,9 @@ class ParallelQuery(Parallelizer.Parallelizer):
             if issubclass(type(response), list):
                 for req, resp in zip(query[start:end], response[start:end]):
                     for k in req:
-                        # Ref to https://docs.aperturedata.io/query_language/Reference/shared_command_parameters/blobs
-                        blobs_where_default_true = \
-                            k in ["FindImage", "FindBlob", "FindVideo"] and (
-                                "blobs" not in req[k] or req[k]["blobs"])
-                        blobs_where_default_false = \
-                            k in [
-                                "FindDescriptor", "FindBoundingBox"] and "blobs" in req[k] and req[k]["blobs"]
-                        if blobs_where_default_true or blobs_where_default_false:
+                        blob_returning_commands = ["FindImage", "FindBlob", "FindVideo",\
+                                "FindDescriptor", "FindBoundingBox"]
+                        if k in blob_returning_commands and "blobs" in req[k] and req[k]["blobs"]:
                             count = resp[k]["returned"]
                             b_count += count
 

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -126,8 +126,8 @@ class ParallelQuery(Parallelizer.Parallelizer):
             if issubclass(type(response), list):
                 for req, resp in zip(query[start:end], response[start:end]):
                     for k in req:
-                        blob_returning_commands = ["FindImage", "FindBlob", "FindVideo",\
-                                "FindDescriptor", "FindBoundingBox"]
+                        blob_returning_commands = ["FindImage", "FindBlob", "FindVideo",
+                                                   "FindDescriptor", "FindBoundingBox"]
                         if k in blob_returning_commands and "blobs" in req[k] and req[k]["blobs"]:
                             count = resp[k]["returned"]
                             b_count += count

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -46,45 +46,16 @@ def execute_batch(q: Commands, blobs: Blobs, db: Connector,
     r, b = db.query(q, blobs)
     logger.debug(f"Response={r}")
 
+
     if db.last_query_ok():
         if response_handler is not None:
-            # We could potentially always call this handler function
-            # and let the user deal with the error cases.
-            blobs_returned = 0
-            for i in range(math.ceil(len(q) / commands_per_query)):
-                start = i * commands_per_query
-                end = start + commands_per_query
-                blobs_start = i * blobs_per_query
-                blobs_end = blobs_start + blobs_per_query
-
-                b_count = 0
-                if issubclass(type(r), list):
-                    for req, resp in zip(q[start:end], r[start:end]):
-                        for k in req:
-                            # Ref to https://docs.aperturedata.io/query_language/Reference/shared_command_parameters/blobs
-                            blobs_where_default_true = \
-                                k in ["FindImage", "FindBlob", "FindVideo"] and (
-                                    "blobs" not in req[k] or req[k]["blobs"])
-                            blobs_where_default_false = \
-                                k in [
-                                    "FindDescriptor", "FindBoundingBox"] and "blobs" in req[k] and req[k]["blobs"]
-                            if blobs_where_default_true or blobs_where_default_false:
-                                count = resp[k]["returned"]
-                                b_count += count
-
                 try:
-                    # The returned blobs need to be sliced to match the
-                    # returned entities per command in query.
-                    response_handler(
-                        q[start:end],
-                        blobs[blobs_start:blobs_end],
-                        r[start:end] if issubclass(type(r), list) else r,
-                        b[blobs_returned:blobs_returned + b_count] if len(b) >= blobs_returned + b_count else None)
+                    ParallelQuery.map_response_to_handler( response_handler,
+                            q,blobs,r,b,commands_per_query,blobs_per_query)
                 except BaseException as e:
                     logger.exception(e)
                     if strict_response_validation:
                         raise e
-                blobs_returned += b_count
     else:
         # Transaction failed entirely.
         logger.error(f"Failed query = {q} with response = {r}")
@@ -139,6 +110,43 @@ class ParallelQuery(Parallelizer.Parallelizer):
     @classmethod
     def getSuccessStatus(cls):
         return cls.success_statuses
+
+    @classmethod
+    def map_response_to_handler(cls, handler, query, query_blobs,  response, response_blobs,
+            commands_per_query, blobs_per_query ):
+            # We could potentially always call this handler function
+            # and let the user deal with the error cases.
+            blobs_returned = 0
+            for i in range(math.ceil(len(query) / commands_per_query)):
+                start = i * commands_per_query
+                end = start + commands_per_query
+                blobs_start = i * blobs_per_query
+                blobs_end = blobs_start + blobs_per_query
+
+                b_count = 0
+                if issubclass(type(response), list):
+                    for req, resp in zip(query[start:end], response[start:end]):
+                        for k in req:
+                            # Ref to https://docs.aperturedata.io/query_language/Reference/shared_command_parameters/blobs
+                            blobs_where_default_true = \
+                                k in ["FindImage", "FindBlob", "FindVideo"] and (
+                                    "blobs" not in req[k] or req[k]["blobs"])
+                            blobs_where_default_false = \
+                                k in [
+                                    "FindDescriptor", "FindBoundingBox"] and "blobs" in req[k] and req[k]["blobs"]
+                            if blobs_where_default_true or blobs_where_default_false:
+                                count = resp[k]["returned"]
+                                b_count += count
+
+                # The returned blobs need to be sliced to match the
+                # returned entities per command in query.
+                handler(
+                    query[start:end],
+                    query_blobs[blobs_start:blobs_end],
+                    response[start:end] if issubclass(type(response), list) else response,
+                    response_blobs[blobs_returned:blobs_returned + b_count] if
+                        len(response_blobs) >= blobs_returned + b_count else None)
+                blobs_returned += b_count
 
     def __init__(self, db: Connector, dry_run: bool = False):
 

--- a/aperturedb/ParallelQuerySet.py
+++ b/aperturedb/ParallelQuerySet.py
@@ -373,7 +373,7 @@ class ParallelQuerySet(ParallelQuery):
         self.blobs_per_query = self.generator.blobs_per_query
         set_response_handler = None
         self.batch_command = gen_execute_batch_sets(
-            self.base_batch_command )
+            self.base_batch_command)
 
         ParallelQuery.do_batch(self, db, data)
 

--- a/aperturedb/ParallelQuerySet.py
+++ b/aperturedb/ParallelQuerySet.py
@@ -280,18 +280,19 @@ def gen_execute_batch_sets(base_executor, per_batch_response_handler: Callable =
 
             # filter out struck blobs
             used_blobs = list(filter(lambda b: b is not None,
-                                blob_filter(blob_set, blob_strike_list, i)))
+                                     blob_filter(blob_set, blob_strike_list, i)))
 
             if len(executable_queries) > 0:
                 result_code, db_results, db_blobs = base_executor(executable_queries, used_blobs,
                                                                   db, local_success_statuses,
                                                                   None, commands_per_query[i], blobs_per_query[i], strict_response_validation=strict_response_validation)
                 if response_handler != None and db.last_query_ok():
-                    def map_to_set( query, query_blobs, resp,resp_blobs ):
-                        response_handler(i,query,query_blobs,resp,resp_blobs)
+                    def map_to_set(query, query_blobs, resp, resp_blobs):
+                        response_handler(
+                            i, query, query_blobs, resp, resp_blobs)
                     try:
-                        ParallelQuery.map_response_to_handler( map_to_set,
-                                executable_queries,used_blobs,db_results,db_blobs,commands_per_query[i],blobs_per_query[i])
+                        ParallelQuery.map_response_to_handler(map_to_set,
+                                                              executable_queries, used_blobs, db_results, db_blobs, commands_per_query[i], blobs_per_query[i])
                     except BaseException as e:
                         logger.exception(e)
                         if strict_response_validation:

--- a/aperturedb/ParallelQuerySet.py
+++ b/aperturedb/ParallelQuerySet.py
@@ -29,7 +29,7 @@ def remove_blobs(item: Any) -> Any:
     return item
 
 
-def gen_execute_batch_sets(base_executor, per_batch_response_handler: Callable = None):
+def gen_execute_batch_sets(base_executor):
 
     #
     # execute_batch_sets - executes multiple sets of queries with optional constraints on follow on sets
@@ -156,9 +156,9 @@ def gen_execute_batch_sets(base_executor, per_batch_response_handler: Callable =
 
             # allowed layouts for commands other than the seed command
             # { "cmd" : {} } -> standard single command
-            # [{ "cmd1": {}, "cmd2} : {}] -> standard multiple command
-            # [{ "constraint" : {} , { "cmd" : {} }] -> constraint with a single command
-            # [{ "constraints: {} , [{"cmd1" : {} }, {"cmd2": {} }]] -> constraint with multiple command
+            # [{ "cmd1": {} },{ "cmd2" : {} }] -> standard multiple command
+            # [{ constraints } , { "cmd" : {} }] -> constraint with a single command
+            # [{ constraints } , [{"cmd1" : {} }, {"cmd2": {} }]] -> constraint with multiple command
 
             known_constraint_keys = ["results", "apply"]
             constraints = None
@@ -372,10 +372,8 @@ class ParallelQuerySet(ParallelQuery):
         self.commands_per_query = self.generator.commands_per_query
         self.blobs_per_query = self.generator.blobs_per_query
         set_response_handler = None
-        if hasattr(self.generator, "set_response_handler") and callable(self.generator.set_response_handler):
-            set_response_handler = self.generator.set_response_handler
         self.batch_command = gen_execute_batch_sets(
-            self.base_batch_command, set_response_handler)
+            self.base_batch_command )
 
         ParallelQuery.do_batch(self, db, data)
 

--- a/aperturedb/ParallelQuerySet.py
+++ b/aperturedb/ParallelQuerySet.py
@@ -73,9 +73,10 @@ def gen_execute_batch_sets(base_executor):
 
             if len(first_element_blobs) == 0 or len(first_element_blobs) != set_total:
                 # user has confused blob format for sure.
-                logger.error("Malformed blobs for first element. Blob return from your loader " 
-                        "should be [query_blobs] where query_blobs = [ first_cmd_list, second_cmd_list, ... ] ")
-                raise Exception("Malformed blobs input. Expected First element to have a list of blobs for each set.")
+                logger.error("Malformed blobs for first element. Blob return from your loader "
+                             "should be [query_blobs] where query_blobs = [ first_cmd_list, second_cmd_list, ... ] ")
+                raise Exception(
+                    "Malformed blobs input. Expected First element to have a list of blobs for each set.")
 
             first_query_blobs = first_element_blobs[0]
             # If someone is looking for info logging from PQS, it is likely that blobs are not being set properly.
@@ -210,9 +211,9 @@ def gen_execute_batch_sets(base_executor):
                         passed_all_constraints = True
                         for result_number in result_constraints:
 
-                            if not isinstance(result_number,int):
-                                raise Exception("Keys for result constraints must be numbers: "\
-                                        f"{result_number} is {type(result_number)}")
+                            if not isinstance(result_number, int):
+                                raise Exception("Keys for result constraints must be numbers: "
+                                                f"{result_number} is {type(result_number)}")
 
                             if len(single_results) < result_number or single_results[result_number] is None:
                                 # in theory here we have two possibilities: a user can have a correctly formed constraint which didn't execute by design

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -312,6 +312,8 @@ class TestResponseHandler():
         querier.query(generator, batchsize=99,
                       numthreads=31,
                       stats=True)
+
+        assert querier.error_counter == 0
         for i, set_key in enumerate(self.responses):
             if set_key in self.response_blobs:
                 assert len(self.response_blobs[set_key]) == \

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -320,14 +320,6 @@ class TestResponseHandler():
                       numthreads=31,
                       stats=True)
 
-        def expected_blobs_for_resp(rh_responses):
-            i = 0
-            for r in rh_responses:
-                k = list(r.keys())[0]
-                if k == "AddImage" and r[k]["status"] == 0:
-                    i = i + 1
-            return i
-
         assert querier.error_counter == 0
         for i, set_key in enumerate(self.responses):
             if set_key in self.response_blobs:

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -95,7 +95,7 @@ class QGImages(QGPersons):
         for i in range(self.cpq):
             q = {
                 "FindImage": {
-                    "blobs":True
+                    "blobs": True
                 }
             }
             query.append(q)

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -121,33 +121,33 @@ class QGSetPersonAndImages(Subscriptable):
     def getitem(self, subscript):
         query_set = []
         entityquery = {
-                "AddEntity":{
-                    "with_class": "Person",
-                    "properties": {
-                        "age":(subscript + 20 )
-                        },
-                    "constraint": {
-                        "age": ["==", (subscript + 20 )]
-                    }
+            "AddEntity": {
+                "with_class": "Person",
+                "properties": {
+                    "age": (subscript + 20)
+                },
+                "constraint": {
+                    "age": ["==", (subscript + 20)]
                 }
+            }
         }
         # add image if entity doesn't exist.
         image_constraint = {"results": {0: {"status": ["!=", 2]}}}
 
         imagequery = {
-                "AddImage": {
-                    "properties": {
-                        "type": "portrait",
-                        "age":(subscript + 20 )
-                    }
+            "AddImage": {
+                "properties": {
+                    "type": "portrait",
+                    "age": (subscript + 20)
                 }
+            }
         }
         query_set.append(entityquery)
         query_set.append([image_constraint, imagequery])
 
-        entity_blobs=[]
-        image_blobs=[subscript]
-        set_blobs = [ entity_blobs,image_blobs]
+        entity_blobs = []
+        image_blobs = [subscript]
+        set_blobs = [entity_blobs, image_blobs]
         return [query_set], [set_blobs]
 
     def response_handler(self, set_id, request, input_blob, response, output_blob):
@@ -200,7 +200,7 @@ def set_query_mocker_factory(response_blobs_count):
         mock_responses = [{
             cmd: {
                 "returned": (i + 1),
-                "status": 0 if i%2 ==0 or cmd_is_image else 2
+                "status": 0 if i % 2 == 0 or cmd_is_image else 2
             }
         } for i, c in enumerate(request)]
         mock_blobs = [i for i in range(
@@ -322,7 +322,7 @@ class TestResponseHandler():
 
         def expected_blobs_for_resp(rh_responses):
             i = 0
-            for r in rh_responses :
+            for r in rh_responses:
                 k = list(r.keys())[0]
                 if k == "AddImage" and r[k]["status"] == 0:
                     i = i + 1
@@ -341,8 +341,8 @@ class TestResponseHandler():
                             expected_status = 2
                         assert part[key]["status"] == expected_status
                         if key == "AddImage":
-                            assert( self.response_blobs[set_key][j]
-                                    == j *2 )
+                            assert(self.response_blobs[set_key][j]
+                                   == j * 2)
                             expected_blobs = expected_blobs + 1
                         else:
                             assert part[key]["returned"] == j + 1

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -95,7 +95,7 @@ class QGImages(QGPersons):
         for i in range(self.cpq):
             q = {
                 "FindImage": {
-
+                    "blobs":True
                 }
             }
             query.append(q)

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -112,8 +112,8 @@ class QGSetPersonAndImages(Subscriptable):
         self.responses = responses
         self.response_blobs = response_blobs
         self.cpq = cpq
-        self.commands_per_query = [cpq,cpq]
-        self.blobs_per_query = [0,0]
+        self.commands_per_query = [cpq, cpq]
+        self.blobs_per_query = [0, 0]
 
     def __len__(self):
         return math.ceil(10 / self.cpq)

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -112,6 +112,8 @@ class QGSetPersonAndImages(Subscriptable):
         self.responses = responses
         self.response_blobs = response_blobs
         self.cpq = cpq
+        self.commands_per_query = [cpq,cpq]
+        self.blobs_per_query = [0,0]
 
     def __len__(self):
         return math.ceil(10 / self.cpq)
@@ -146,7 +148,7 @@ class QGSetPersonAndImages(Subscriptable):
         query.append(entityquery if len(entityquery) > 1 else entityquery[0])
         query.append([image_constraint, imagequery if len(imagequery) > 1
                       else imagequery[0]])
-        return query, []
+        return [query], []
 
     def response_handler(self, set_id, request, input_blob, response, output_blob):
         if not set_id in self.requests:


### PR DESCRIPTION
Move response_handler generation into ParallelQuery, simplyfing execute_batch.
Adds response_handler for ParallelQuerySet, defined as set_number,query,query_blobs,response,response_blobs.