### PR TITLE
Add descriptorset properties

### DIFF
--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -6,7 +6,7 @@ import json
 import os
 import importlib
 import sys
-from typing import List
+from typing import List, Optional, Dict
 
 from graphviz import Source, Digraph
 
@@ -522,7 +522,8 @@ class Utils(object):
 
         return total_connections
 
-    def add_descriptorset(self, name: str, dim: int, metric="L2", engine="FaissFlat") -> bool:
+    def add_descriptorset(self, name: str, dim: int, metric="L2", engine="FaissFlat",
+                          properties: Optional[Dict] = None) -> bool:
         """
         Add a descriptor set to the database.
 
@@ -531,6 +532,7 @@ class Utils(object):
             dim (int): The dimension of the descriptors.
             metric (str, optional): The metric to use for the descriptors.
             engine (str, optional): The engine to use for the descriptors.
+            properties (dict, optional): The properties of the descriptor set.
 
         Returns:
             success (bool): True if the operation was successful, False otherwise.
@@ -543,6 +545,9 @@ class Utils(object):
                 "engine":     engine
             }
         }]
+
+        if properties is not None:
+            query[0]["AddDescriptorSet"]["properties"] = properties
 
         try:
             self.execute(query)


### PR DESCRIPTION
Adding optional properties parameter to `Utils.add_descriptorset`.  This is useful for clients that want to record information about the descriptorset.  I plan to use it in the langchain integration.