### PR TITLE
Pin numpy to less than 2.

### DIFF
--- a/docker/dependencies/Dockerfile
+++ b/docker/dependencies/Dockerfile
@@ -33,7 +33,7 @@ ENV PATH="/opt/node-${NODEJS_LTS}-linux-x64/bin:$PATH"
 # --     Libraries:                   /usr/lib/x86_64-linux-gnu/libpython3.10.so (ver 3.10.6)
 # --     numpy:                       /opt/venv/lib/python3.10/site-packages/numpy/core/include (ver 1.24.1)
 # --     install path:                lib/python3.10/site-packages/cv2/python-3.10
-RUN pip install numpy<2
+RUN pip install "numpy<2"
 
 RUN wget -q https://github.com/opencv/opencv/archive/$OPENCV_VERSION.tar.gz && \
     tar xf $OPENCV_VERSION.tar.gz && rm $OPENCV_VERSION.tar.gz && \

--- a/docker/dependencies/Dockerfile
+++ b/docker/dependencies/Dockerfile
@@ -33,7 +33,7 @@ ENV PATH="/opt/node-${NODEJS_LTS}-linux-x64/bin:$PATH"
 # --     Libraries:                   /usr/lib/x86_64-linux-gnu/libpython3.10.so (ver 3.10.6)
 # --     numpy:                       /opt/venv/lib/python3.10/site-packages/numpy/core/include (ver 1.24.1)
 # --     install path:                lib/python3.10/site-packages/cv2/python-3.10
-RUN pip install numpy
+RUN pip install numpy<2
 
 RUN wget -q https://github.com/opencv/opencv/archive/$OPENCV_VERSION.tar.gz && \
     tar xf $OPENCV_VERSION.tar.gz && rm $OPENCV_VERSION.tar.gz && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     #Folllowing is needed parallel loaders, and basic things for
     # making the notebooks.
     'scikit-image', 'image', 'requests', 'boto3',
-    'numpy', 'matplotlib', 'pandas', 'kaggle', 'google-cloud-storage',
+    'numpy<2', 'matplotlib', 'pandas', 'kaggle', 'google-cloud-storage',
     'ipython', 'dask[complete]', 'ipywidgets', 'pydantic', 'devtools', 'typer[all]',
     "opencv-python-headless",
     # Pinning this to be able to install google-cloud-bigquery


### PR DESCRIPTION
numpy 2.0 creates incompatibility, and was released on Jun 16.
Pinning this till a better fix is available.