### PR TITLE
Colab logging

### DIFF
--- a/aperturedb/__init__.py
+++ b/aperturedb/__init__.py
@@ -22,8 +22,9 @@ log_console_level = logging.getLevelName(
 # Set the logger filter to the minimum (more chatty) of the two handler levels
 # This reduces problems if the environment adds a root handler (e.g. Google Colab)
 logger_level = min(log_file_level, log_console_level)
-if any( log_control in os.environ for log_control in [ "LOG_CONSOLE_LEVEL", "LOG_FILE_LEVEL" ]):
-   logger.setLevel(logger_level)
+if any(log_control in os.environ
+       for log_control in ["LOG_CONSOLE_LEVEL", "LOG_FILE_LEVEL"]):
+    logger.setLevel(logger_level)
 
 # define file handler and set formatter
 error_file_name = "error.${now}.log"

--- a/aperturedb/__init__.py
+++ b/aperturedb/__init__.py
@@ -12,13 +12,17 @@ logger = logging.getLogger(__name__)
 __version__ = "0.4.30"
 
 # set log level
-logger.setLevel(logging.DEBUG)
-formatter    = logging.Formatter(
+formatter = logging.Formatter(
     "%(asctime)s : %(levelname)s : %(name)s : %(thread)d : %(lineno)d : %(message)s")
 
 log_file_level = logging.getLevelName(os.getenv("LOG_FILE_LEVEL", "WARN"))
 log_console_level = logging.getLevelName(
     os.getenv("LOG_CONSOLE_LEVEL", "ERROR"))
+
+# Set the logger filter to the minimum (more chatty) of the two handler levels
+# This reduces problems if the environment adds a root handler (e.g. Google Colab)
+logger_level = min(log_file_level, log_console_level)
+logger.setLevel(logging.DEBUG)
 
 # define file handler and set formatter
 error_file_name = "error.${now}.log"

--- a/aperturedb/__init__.py
+++ b/aperturedb/__init__.py
@@ -22,7 +22,8 @@ log_console_level = logging.getLevelName(
 # Set the logger filter to the minimum (more chatty) of the two handler levels
 # This reduces problems if the environment adds a root handler (e.g. Google Colab)
 logger_level = min(log_file_level, log_console_level)
-logger.setLevel(logger_level)
+if any( log_control in os.environ for log_control in [ "LOG_CONSOLE_LEVEL", "LOG_FILE_LEVEL" ]):
+   logger.setLevel(logger_level)
 
 # define file handler and set formatter
 error_file_name = "error.${now}.log"

--- a/aperturedb/__init__.py
+++ b/aperturedb/__init__.py
@@ -21,6 +21,7 @@ log_console_level = logging.getLevelName(
 
 # Set the logger filter to the minimum (more chatty) of the two handler levels
 # This reduces problems if the environment adds a root handler (e.g. Google Colab)
+print("Setting log level by minumum of file and console levels")
 logger_level = min(log_file_level, log_console_level)
 logger.setLevel(logging.DEBUG)
 

--- a/aperturedb/__init__.py
+++ b/aperturedb/__init__.py
@@ -21,9 +21,8 @@ log_console_level = logging.getLevelName(
 
 # Set the logger filter to the minimum (more chatty) of the two handler levels
 # This reduces problems if the environment adds a root handler (e.g. Google Colab)
-print("Setting log level by minumum of file and console levels")
 logger_level = min(log_file_level, log_console_level)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logger_level)
 
 # define file handler and set formatter
 error_file_name = "error.${now}.log"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     #Folllowing is needed parallel loaders, and basic things for
     # making the notebooks.
     'scikit-image', 'image', 'requests', 'boto3',
-    'numpy<2', 'matplotlib', 'pandas', 'kaggle', 'google-cloud-storage',
+    # https://github.com/Kaggle/kaggle-api/issues/611
+    'numpy<2', 'matplotlib', 'pandas', 'kaggle!=1.6.15', 'google-cloud-storage',
     'ipython', 'dask[complete]', 'ipywidgets', 'pydantic', 'devtools', 'typer[all]',
     "opencv-python-headless",
     # Pinning this to be able to install google-cloud-bigquery


### PR DESCRIPTION
Google Colab sets up logging slightly differently from Jupyter.  Specifically it creates a `<StreamHandler stderr (NOTSET)>` handler on the root logger.  This means that if a library (like ours) sets the logger level to DEBUG, then it gets printed, regardless of the level on the handlers we set up.

With this change, we'll set the logger level to the minimum of the two handler levels if either is explicitly set.

This also includes a fix for an unrelated Kaggle problem. https://github.com/Kaggle/kaggle-api/issues/611