### PR TITLE
Re authenticate when refresh token fails.

### DIFF
--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -268,6 +268,10 @@ class Connector(object):
                 self.authenticated = False
                 self.should_authenticate = True
                 self.shared_data.session = None
+                self.authenticate(self.shared_data,
+                                  self.config.username,
+                                  self.config.password,
+                                  self.token)
                 raise UnauthorizedException(response)
 
             self.shared_data.session = Session(

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -162,8 +162,8 @@ class Connector(object):
     def authenticate(self, shared_data, user, password, token):
         """
         Authenticate with the database. This will be called automatically from query.
-        This is separate from session refresh mechanism, and is called only once.
-        Failure leads to exception.
+        This is separate from session refresh mechanism, and is set to be called only once per session.
+        If a Refresh token also fails, this will be called again.
         """
         if not self.authenticated:
             if shared_data.session is None:
@@ -262,6 +262,12 @@ class Connector(object):
         if isinstance(response, list):
             session_info = response[0]["RefreshToken"]
             if session_info["status"] != 0:
+                # Refresh token failed, we need to re-authenticate
+                # This is possible with a long lived connector, where
+                # the session token and the refresh token have expired.
+                self.authenticated = False
+                self.should_authenticate = True
+                self.shared_data.session = None
                 raise UnauthorizedException(response)
 
             self.shared_data.session = Session(

--- a/test/test_Session.py
+++ b/test/test_Session.py
@@ -228,3 +228,39 @@ class TestSession():
             response, blobs = db.query(query)
             assert(response[0]["FindImage"]["status"] == 0)
             assert count == 3
+
+    def test_invalid_session_recovery(self, db: Connector, monkeypatch):
+        # simulate session invalidation
+        original_query = db._query
+        enable_mock = True
+
+        def mock_refresher(query, blobs=[], try_resume=True):
+            # when enabled, the mock will return a status -1 for the RefreshToken
+            # and a schema query will be used to get not authenticated.
+            nonlocal enable_mock
+            print(f"{query=}")
+            r, b = original_query(query, blobs, try_resume)
+            if enable_mock:
+                if "RefreshToken" in query[0]:
+                    r[0]["RefreshToken"]["status"] = -1
+                if "GetSchema" in query[0]:
+                    r = {"info": "Not Authenticated!", "status": -1}
+                if "Authenticate" in query[0]:
+                    enable_mock = False
+            print(f"{r=}")
+            return r, b
+        monkeypatch.setattr(
+            db,
+            "_query",
+            mock_refresher)
+
+        # Ensure a session validation error
+        db.shared_data.session.session_token_ttl = 0
+        resp, blobs = db.query([{'GetSchema': {}}], [])
+        print(f"{resp=}")
+        assert resp['status'] == -1, f"{resp=}"
+
+        # Ensure the session is reauthenticated
+        resp, blobs = db.query([{'GetSchema': {}}], [])
+        print(f"{resp=}")
+        assert resp[0]['GetSchema']['status'] == 0, f"{resp=}"

--- a/test/test_Session.py
+++ b/test/test_Session.py
@@ -258,9 +258,4 @@ class TestSession():
         db.shared_data.session.session_token_ttl = 0
         resp, blobs = db.query([{'GetSchema': {}}], [])
         print(f"{resp=}")
-        assert resp['status'] == -1, f"{resp=}"
-
-        # Ensure the session is reauthenticated
-        resp, blobs = db.query([{'GetSchema': {}}], [])
-        print(f"{resp=}")
-        assert resp[0]['GetSchema']['status'] == 0, f"{resp=}"
+        assert enable_mock == False, "Authentication query was not invoked"


### PR DESCRIPTION
fix for #484 

- [x] It recovers in subsequent calls to query. Make it kick in the current query.