### PR TITLE
Drop extra from typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     'scikit-image', 'image', 'requests', 'boto3',
     # https://github.com/Kaggle/kaggle-api/issues/611
     'numpy<2', 'matplotlib', 'pandas', 'kaggle!=1.6.15', 'google-cloud-storage',
-    'ipython', 'dask[complete]', 'ipywidgets', 'pydantic>=2.6.0', 'devtools', 'typer[all]',
+    'ipython', 'dask[complete]', 'ipywidgets', 'pydantic>=2.6.0', 'devtools', 'typer',
     "opencv-python-headless",
     # Pinning this to be able to install google-cloud-bigquery
     'grpcio-status==1.48.2',


### PR DESCRIPTION
As of typer 0.12.1 you no longer need to add the `typer[all]`, you can just use `typer`

See: https://typer.tiangolo.com/release-notes/#0121