### PR TITLE
switch declaration order in images

### DIFF
--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -427,12 +427,12 @@ class Images(Entities):
         uniqueid_str = str(uniqueid)
         self.images_bboxes[uniqueid_str] = {}
         try:
-            result, res, images = execute_query(
-                client=self.client, q=query, blobs=[])
             bboxes = []
             tags = []
             meta = []
             bounds = []
+            result, res, images = execute_query(
+                client=self.client, q=query, blobs=[])
             if "entities" in res[1]["FindBoundingBox"]:
                 for bbox in res[1]["FindBoundingBox"]["entities"]:
                     coordinates = bbox["_coordinates"]


### PR DESCRIPTION
When execution fails we get a spurious error of local variables not defined.