### PR TITLE
Make create_connection use dotenv and google colab secrets

### DIFF
--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -90,10 +90,8 @@ def _create_configuration_from_json(config: Union[Dict, str]) -> Connector:
 def _get_colab_secret(name: str) -> Optional[str]:
     try:
         from google.colab import userdata
-        print("Checking for secret in colab")
         return userdata.get(name)
     except ImportError:  # Not on colab
-        print("Not on colab")
         return None
 
 

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -90,8 +90,10 @@ def _create_configuration_from_json(config: Union[Dict, str]) -> Connector:
 def _get_colab_secret(name: str) -> Optional[str]:
     try:
         from google.colab import userdata
+        print("Checking for secret in colab")
         return userdata.get(name)
     except ImportError:  # Not on colab
+        print("Not on colab")
         return None
 
 
@@ -129,9 +131,13 @@ def create_connector(name: Optional[str] = None) -> Connector:
         Connector: The connector to the database.
     """
     from aperturedb.cli.configure import ls
-    all_configs = ls(log_to_console=False)
+    all_configs = None
 
     def lookup_config_by_name(name: str, source: str) -> Configuration:
+        nonlocal all_configs
+        if all_configs is None:
+            all_configs = ls(log_to_console=False)
+
         if "global" in all_configs and name in all_configs["global"]:
             return all_configs["global"][name]
         if "local" in all_configs and name in all_configs["local"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     'ipywidgets==8.0.4',
     'keepalive-socket==0.0.1',
     'graphviz==0.20.2',
-    "dotenv",
+    "python-dotenv",
 ]
 
 [tool.setuptools.package-dir]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     # Pinning this to resolve test errors temporarily
     'ipywidgets==8.0.4',
     'keepalive-socket==0.0.1',
-    'graphviz==0.20.2'
+    'graphviz==0.20.2',
+    "dotenv",
 ]
 
 [tool.setuptools.package-dir]


### PR DESCRIPTION
This changes the behaviour of `create_connector` so that it can create a connection using a JSON object.  This object can come from one of three sources:
* Environment variable called `APERTUREDB_JSON`
* `.env` file entry  called `APERTUREDB_JSON`
* Google Colab secret called called `APERTUREDB_JSON`