### PR TITLE
Add --from-json to adb config create

### DIFF
--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -89,9 +89,19 @@ def _create_configuration_from_json(config: Union[Dict, str]) -> Connector:
 
 def _get_colab_secret(name: str) -> Optional[str]:
     try:
-        from google.colab import userdata
+        from google.colab import userdata, NotebookAccessError, SecretNotFoundError
         return userdata.get(name)
-    except (ImportError, AttributeError):  # Not in Colab Notebook
+    except ImportError:  # Not in Colab environment
+        return None
+    except AttributeError:  # In Colab environment but not in a notebook
+        return None
+    except NotebookAccessError:  # Permission to access secrets not granted
+        return None
+    except SecretNotFoundError:  # This secret does not exist
+        return None
+    except Exception as e:  # Unexpected error
+        logger.error(
+            f"Unexpected error while reading secret '{name}' from Google Colab: {e}")
         return None
 
 

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -91,15 +91,21 @@ def _get_colab_secret(name: str) -> Optional[str]:
     try:
         from google.colab import userdata, NotebookAccessError, SecretNotFoundError
         return userdata.get(name)
-    except ImportError:  # Not in Colab environment
+    except ImportError:         # Not in Colab environment
         return None
-    except AttributeError:  # In Colab environment but not in a notebook
+    except AttributeError:      # In Colab environment but not in a notebook
+        logger.debug(
+            "In Colab environment but not in a notebook. Cannot read secrets.")
         return None
     except NotebookAccessError:  # Permission to access secrets not granted
+        logger.debug(
+            "Permission to access secrets not granted to this notebook.")
         return None
     except SecretNotFoundError:  # This secret does not exist
+        logger.debug(
+            f"Secret '{name}' not found in Google Colab.")
         return None
-    except Exception as e:  # Unexpected error
+    except Exception as e:       # Unexpected error
         logger.error(
             f"Unexpected error while reading secret '{name}' from Google Colab: {e}")
         return None

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -89,7 +89,7 @@ def _create_configuration_from_json(config: Union[Dict, str]) -> Connector:
 
 def _get_colab_secret(name: str) -> Optional[str]:
     try:
-        from google.colab import userdata, NotebookAccessError, SecretNotFoundError
+        from google.colab import userdata
         return userdata.get(name)
     except ImportError:         # Not in Colab environment
         return None
@@ -97,11 +97,11 @@ def _get_colab_secret(name: str) -> Optional[str]:
         logger.debug(
             "In Colab environment but not in a notebook. Cannot read secrets.")
         return None
-    except NotebookAccessError:  # Permission to access secrets not granted
+    except usedata.NotebookAccessError:  # Permission to access secrets not granted
         logger.debug(
             "Permission to access secrets not granted to this notebook.")
         return None
-    except SecretNotFoundError:  # This secret does not exist
+    except userdata.SecretNotFoundError:  # This secret does not exist
         logger.debug(
             f"Secret '{name}' not found in Google Colab.")
         return None

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -91,13 +91,13 @@ def _get_colab_secret(name: str) -> Optional[str]:
     try:
         from google.colab import userdata
         return userdata.get(name)
-    except ImportError:         # Not in Colab environment
+    except ImportError:  # Not in Colab environment
         return None
-    except AttributeError:      # In Colab environment but not in a notebook
+    except AttributeError:  # In Colab environment but not in a notebook
         logger.debug(
             "In Colab environment but not in a notebook. Cannot read secrets.")
         return None
-    except usedata.NotebookAccessError:  # Permission to access secrets not granted
+    except userdata.NotebookAccessError:  # Permission to access secrets not granted
         logger.debug(
             "Permission to access secrets not granted to this notebook.")
         return None
@@ -105,7 +105,7 @@ def _get_colab_secret(name: str) -> Optional[str]:
         logger.debug(
             f"Secret '{name}' not found in Google Colab.")
         return None
-    except Exception as e:       # Unexpected error
+    except Exception as e:  # Unexpected error
         logger.error(
             f"Unexpected error while reading secret '{name}' from Google Colab: {e}")
         return None

--- a/aperturedb/cli/configure.py
+++ b/aperturedb/cli/configure.py
@@ -131,7 +131,7 @@ def create(
     1) The environment variable APERTUREDB_JSON;
     2) An entry for APERTUREDB_JSON in a .env file;
     3) In interactive mode, the user will be prompted to enter the JSON string.  This will be treated as a password entry.
-    See https://docs.aperturedata.dev/Setup/client/notebooks for more information on JSON configurations.
+    See https://docs.aperturedata.dev/Setup/client/configuration for more information on JSON configurations.
     """
 
     db_host = host

--- a/aperturedb/cli/configure.py
+++ b/aperturedb/cli/configure.py
@@ -8,6 +8,7 @@ from typing_extensions import Annotated
 
 from aperturedb.cli.console import console
 from aperturedb.Configuration import Configuration
+from aperturedb.CommonLibrary import _create_configuration_from_json
 
 
 class ObjEncoder(JSONEncoder):
@@ -119,10 +120,20 @@ def create(
         use_ssl: Annotated[bool, typer.Option(help="Use SSL")] = True,
         interactive: Annotated[bool, typer.Option(
             help="Interactive mode")] = True,
-        overwrite: Annotated[bool, typer.Option(help="overwrite existing configuration")] = False):
+        overwrite: Annotated[bool, typer.Option(
+            help="overwrite existing configuration")] = False,
+        from_json: Annotated[bool, typer.Option(help="create config from a JSON string")] = False):
     """
     Create a new configuration for the client.
+
+    If --from-json is used, then the options --host, --port, --username, --password, --use-rest, and --use-ssl will be ignored.  
+    The JSON string will be obtained from one of the following places (in order):
+    1) The environment variable APERTUREDB_JSON;
+    2) An entry for APERTUREDB_JSON in a .env file;
+    3) In interactive mode, the user will be prompted to enter the JSON string.  This will be treated as a password entry.
+    See https://docs.aperturedata.dev/Setup/client/notebooks for more information on JSON configurations.
     """
+
     db_host = host
     db_port = port
     db_username = username
@@ -149,28 +160,49 @@ def create(
             style="bold yellow")
         raise typer.Exit(code=2)
 
-    if interactive:
-        db_host = typer.prompt(f"Enter {APP_NAME} host name", default=db_host)
-        db_port = typer.prompt(
-            f"Enter {APP_NAME} port number", default=db_port)
-        db_username = typer.prompt(
-            f"Enter {APP_NAME} username", default=db_username)
-        db_password = typer.prompt(
-            f"Enter {APP_NAME} password", hide_input=True, default=db_password)
-        db_use_rest = typer.confirm(
-            f"Use REST [Note: Only if ApertureDB is setup to recieve http requests]", default=db_use_rest)
-        db_use_ssl = typer.confirm(
-            f"Use SSL [Note: ApertureDB's defaults do not allow non SSL traffic]", default=db_use_ssl)
+    if from_json:
+        json_str = os.getenv("APERTUREDB_JSON")
+        if json_str is None:
+            try:
+                from dotenv import dotenv_values
+                env = dotenv_values(".env")
+                json_str = env.get("APERTUREDB_JSON")
+            except ImportError:
+                console.log("Unable to use the dotenv package")
+                pass
+        if json_str is None:
+            if interactive:
+                json_str = typer.prompt(
+                    "Enter JSON string", hide_input=True)
+        if json_str is None:
+            console.log(
+                "JSON string not found. Please set APERTUREDB_JSON environment variable create a .env file with APERTUREDB_JSON entry, or enter JSON in interactive mode")
+            return
+        gen_config = _create_configuration_from_json(json_str)
+    else:
+        if interactive:
+            db_host = typer.prompt(
+                f"Enter {APP_NAME} host name", default=db_host)
+            db_port = typer.prompt(
+                f"Enter {APP_NAME} port number", default=db_port)
+            db_username = typer.prompt(
+                f"Enter {APP_NAME} username", default=db_username)
+            db_password = typer.prompt(
+                f"Enter {APP_NAME} password", hide_input=True, default=db_password)
+            db_use_rest = typer.confirm(
+                f"Use REST [Note: Only if ApertureDB is setup to receive HTTP requests]", default=db_use_rest)
+            db_use_ssl = typer.confirm(
+                f"Use SSL [Note: ApertureDB's defaults do not allow non SSL traffic]", default=db_use_ssl)
 
-    gen_config = Configuration(
-        name=name,
-        host=db_host,
-        port=db_port,
-        username=db_username,
-        password=db_password,
-        use_ssl=db_use_ssl,
-        use_rest=db_use_rest
-    )
+        gen_config = Configuration(
+            name=name,
+            host=db_host,
+            port=db_port,
+            username=db_username,
+            password=db_password,
+            use_ssl=db_use_ssl,
+            use_rest=db_use_rest
+        )
 
     configs[name] = gen_config
     if active:

--- a/aperturedb/cli/configure.py
+++ b/aperturedb/cli/configure.py
@@ -176,7 +176,7 @@ def create(
                     "Enter JSON string", hide_input=True)
         if json_str is None:
             console.log(
-                "JSON string not found. Please set APERTUREDB_JSON environment variable create a .env file with APERTUREDB_JSON entry, or enter JSON in interactive mode")
+                "JSON string not found. Please set APERTUREDB_JSON environment variable create a .env file with APERTUREDB_JSON entry, or enter config parameters in interactive mode")
             return
         gen_config = _create_configuration_from_json(json_str)
     else:

--- a/aperturedb/cli/configure.py
+++ b/aperturedb/cli/configure.py
@@ -126,7 +126,7 @@ def create(
     """
     Create a new configuration for the client.
 
-    If --from-json is used, then the options --host, --port, --username, --password, --use-rest, and --use-ssl will be ignored.  
+    If --from-json is used, then the options --host, --port, --username, --password, --use-rest, and --use-ssl will be ignored.
     The JSON string will be obtained from one of the following places (in order):
     1) The environment variable APERTUREDB_JSON;
     2) An entry for APERTUREDB_JSON in a .env file;


### PR DESCRIPTION
[ Recreation of https://github.com/aperture-data/aperturedb-python/pull/501 with lower-case branch name ]

Part of a set of changes to optimize quick start, etc.
This change adds a --from-json option to adb config create. If specified, then the normal connection parameters are ignored and instead we look for a JSON string in one of three places:

The environment variable APERTUREDB_JSON
An entry for APERTUREDB_JSON in a .env file
In interactive mode, the user will be prompted to enter the JSON string. This is treated like a password.