### PR TITLE
Make `adb config create --from-json` dumber

### DIFF
--- a/aperturedb/cli/configure.py
+++ b/aperturedb/cli/configure.py
@@ -155,6 +155,7 @@ def create(
     except json.JSONDecodeError:
         active = True
 
+    # Check if the configuration already exists (before interaction)
     if name is not None and name in configs and not overwrite:
         console.log(
             f"Configuration named '{name}' already exists. Use --overwrite to overwrite.",
@@ -166,12 +167,6 @@ def create(
         json_str = typer.prompt("Enter JSON string", hide_input=True)
         gen_config = _create_configuration_from_json(
             json_str, name=name, name_required=True)
-
-        if gen_config.name in configs and not overwrite:
-            console.log(
-                f"Configuration named '{gen_config.name}' already exists. Use --overwrite to overwrite.",
-                style="bold yellow")
-            raise typer.Exit(code=2)
     else:
         if interactive:
             if name is None:
@@ -200,6 +195,13 @@ def create(
             use_ssl=db_use_ssl,
             use_rest=db_use_rest
         )
+
+    # Check if the configuration already exists (after interaction)
+    if gen_config.name in configs and not overwrite:
+        console.log(
+            f"Configuration named '{gen_config.name}' already exists. Use --overwrite to overwrite.",
+            style="bold yellow")
+        raise typer.Exit(code=2)
 
     configs[name] = gen_config
     if active:

--- a/aperturedb/cli/configure.py
+++ b/aperturedb/cli/configure.py
@@ -164,7 +164,14 @@ def create(
     if from_json:
         assert interactive, "Interactive mode must be enabled for --from-json"
         json_str = typer.prompt("Enter JSON string", hide_input=True)
-        gen_config = _create_configuration_from_json(json_str)
+        gen_config = _create_configuration_from_json(
+            json_str, name=name, name_required=True)
+
+        if gen_config.name in configs and not overwrite:
+            console.log(
+                f"Configuration named '{gen_config.name}' already exists. Use --overwrite to overwrite.",
+                style="bold yellow")
+            raise typer.Exit(code=2)
     else:
         if interactive:
             if name is None:

--- a/aperturedb/cli/configure.py
+++ b/aperturedb/cli/configure.py
@@ -129,10 +129,9 @@ def create(
     Create a new configuration for the client.
 
     If --from-json is used, then the options --host, --port, --username, --password, --use-rest, and --use-ssl will be ignored.
-    The JSON string will be obtained from one of the following places (in order):
-    1) The environment variable APERTUREDB_JSON;
-    2) An entry for APERTUREDB_JSON in a .env file;
-    3) In interactive mode, the user will be prompted to enter the JSON string.  This will be treated as a password entry.
+    The user will be prompted to enter the JSON string.
+    This will be treated as a password entry.
+
     See https://docs.aperturedata.dev/Setup/client/configuration for more information on JSON configurations.
     """
 
@@ -163,38 +162,9 @@ def create(
         raise typer.Exit(code=2)
 
     if from_json:
-        json_str = os.getenv("APERTUREDB_JSON")
-        if json_str is not None:
-            console.log("Using APERTUREDB_JSON from environment variable")
-
-        if json_str is None:
-            try:
-                from dotenv import dotenv_values
-                env = dotenv_values(".env")
-                json_str = env.get("APERTUREDB_JSON")
-            except ImportError:
-                console.log("Unable to use the dotenv package")
-                pass
-            if json_str is not None:
-                console.log("Using APERTUREDB_JSON from .env file")
-
-        if json_str is None:
-            if interactive:
-                json_str = typer.prompt(
-                    "Enter JSON string", hide_input=True)
-
-        if json_str is None:
-            console.log(
-                "JSON string not found. Please set APERTUREDB_JSON environment variable create a .env file with APERTUREDB_JSON entry, or enter config parameters in interactive mode")
-            return
-
-        try:
-            gen_config = _create_configuration_from_json(
-                json_str, name=name, name_required=True)
-        except AssertionError as e:
-            console.log(str(e))
-            raise typer.Exit(code=2)
-
+        assert interactive, "Interactive mode must be enabled for --from-json"
+        json_str = typer.prompt("Enter JSON string", hide_input=True)
+        gen_config = _create_configuration_from_json(json_str)
     else:
         if interactive:
             if name is None:


### PR DESCRIPTION
After some discussion this morning, we decided that, while we do like the smart behaviour of `CommonLibrary.create_connector`, we want the CLI `adb config create --from-json` to be less smart.  With this change, it will not look at environment variables; it will not look in dotenv files; it will simply accept an interactive input and nothing else.

The name remains optional, and will override the name in the JSON if provided.

I closed a gap whereby names from JSON/interactive were not checked for overwrite.  We now check in three places:
* When the name is given on the command line
* When the name is inferred from the JSON file
* When the name is given interactively