### PR TITLE
modify Images to support Frames as a subclass

### DIFF
--- a/aperturedb/Entities.py
+++ b/aperturedb/Entities.py
@@ -8,6 +8,8 @@ from aperturedb.Connector import Connector
 from aperturedb.CommonLibrary import execute_query
 from aperturedb.Query import QueryBuilder
 import pandas as pd
+import logging
+logger = logging.getLogger(__name__)
 
 
 class Entities(Subscriptable):
@@ -69,10 +71,10 @@ class Entities(Subscriptable):
         cls.client = client
 
         query = spec.query()
-        print(f"query={query}")
+        logger.debug(f"query={query}")
         res, r, b = execute_query(client, query, [])
         if res > 0:
-            print(f"resp={r}")
+            logger.warning(f"resp={r}")
         results = []
         for wc, req, blobs, resp in zip(
                 spec.command_properties(prop="with_class"),
@@ -92,8 +94,8 @@ class Entities(Subscriptable):
 
                 results.append(entities)
             except Exception as e:
-                print(e)
-                print(cls.known_entities)
+                logging.warning(f"Exception: {e}")
+                logging.warning(f"Entities: {cls.known_entities}")
                 raise e
 
         cls.__postprocess__(entities=results[-1], with_adjacent=with_adjacent)
@@ -242,6 +244,11 @@ class Entities(Subscriptable):
             result.append(cl(
                 client=self.client, response=r[1][list(r[1].keys())[0]]["entities"], type=entity_class))
         return result
+
+    def get_object_name(self) -> str:
+        as_str = self.db_object if not isinstance(self.db_object, ObjectType) else self.db_object.value
+        return as_str[1:]
+
 
     def get_blob(self, entity) -> Any:
         """

--- a/aperturedb/Entities.py
+++ b/aperturedb/Entities.py
@@ -262,7 +262,7 @@ class Entities(Subscriptable):
         if self.spec and self.spec.operations:
             cmd_params["operations"] = self.spec.operations.operations_arr
         query = [
-            QueryBuilder().find_command(self.db_object, params=cmd_params)
+            QueryBuilder.find_command(self.db_object, params=cmd_params)
         ]
         res, r, b = execute_query(self.client, query, [])
         return b[0]

--- a/aperturedb/Entities.py
+++ b/aperturedb/Entities.py
@@ -246,9 +246,9 @@ class Entities(Subscriptable):
         return result
 
     def get_object_name(self) -> str:
-        as_str = self.db_object if not isinstance(self.db_object, ObjectType) else self.db_object.value
+        as_str = self.db_object if not isinstance(
+            self.db_object, ObjectType) else self.db_object.value
         return as_str[1:]
-
 
     def get_blob(self, entity) -> Any:
         """

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -257,10 +257,10 @@ class Images(Entities):
         for idx in range(start, end):
 
             find_params = {
-                    "constraints": {
-                        self.img_id_prop: ["==", self.images_ids[idx]]
-                    },
-                    "blobs": True
+                "constraints": {
+                    self.img_id_prop: ["==", self.images_ids[idx]]
+                },
+                "blobs": True
             }
 
             if self.operations and len(self.operations.operations_arr) > 0:
@@ -294,20 +294,20 @@ class Images(Entities):
         uniqueid = self.images_ids[index]
 
         find_image_params = {
-                "_ref": 1,
-                "constraints": {
-                    self.img_id_prop: ["==", uniqueid]
-                },
-                "blobs": False,
-                "results": {
-                    "list": ["adb_image_width", "adb_image_height"]
-                },
-            }
+            "_ref": 1,
+            "constraints": {
+                self.img_id_prop: ["==", uniqueid]
+            },
+            "blobs": False,
+            "results": {
+                "list": ["adb_image_width", "adb_image_height"]
+            },
+        }
 
         find_poly_params = {
-                "image_ref": 1,
-                "bounds": True,
-                "vertices": True,
+            "image_ref": 1,
+            "bounds": True,
+            "vertices": True,
         }
 
         if constraints and constraints.constraints:
@@ -335,17 +335,18 @@ class Images(Entities):
             tags = []
             meta = []
             query = [
-                    QueryBuilder.find_command(
-                        self.db_object, params=find_image_params),
-                    QueryBuilder.find_command(
-                        ObjectType.POLYGON, params=find_poly_params)
-                    ]
+                QueryBuilder.find_command(
+                    self.db_object, params=find_image_params),
+                QueryBuilder.find_command(
+                    ObjectType.POLYGON, params=find_poly_params)
+            ]
             result, res, _ = execute_query(
                 client=self.client, query=query, blobs=[])
 
             if "entities" in res[1]["FindPolygon"]:
                 polys = res[1]["FindPolygon"]["entities"]
-                operations = self.query["operations"] if self.query and "operations" in self.query else [ ]
+                operations = self.query["operations"] if self.query and "operations" in self.query else [
+                ]
                 FindCommand = class_entity(self.db_object)
                 for poly in polys:
                     if tag_key and tag_format:
@@ -403,28 +404,30 @@ class Images(Entities):
         uniqueid = self.images_ids[index]
 
         find_image_params = {
-                "_ref": 1,
-                "constraints": {
-                    self.img_id_prop: ["==", uniqueid]
-                },
-                "results": {
-                    "list": ["adb_image_width", "adb_image_height"]
-                },
-                "blobs": False,
-            }
+            "_ref": 1,
+            "constraints": {
+                self.img_id_prop: ["==", uniqueid]
+            },
+            "results": {
+                "list": ["adb_image_width", "adb_image_height"]
+            },
+            "blobs": False,
+        }
 
         find_bbox_params = {
-                "image_ref": 1,
-                "_ref": 2,
-                "blobs": False,
-                "coordinates": True,
-                "labels": True
-            }
+            "image_ref": 1,
+            "_ref": 2,
+            "blobs": False,
+            "coordinates": True,
+            "labels": True
+        }
 
         query = [
-                QueryBuilder.find_command(self.db_object, params=find_image_params),
-                QueryBuilder.find_command(ObjectType.BOUNDING_BOX, params=find_bbox_params),
-                ]
+            QueryBuilder.find_command(
+                self.db_object, params=find_image_params),
+            QueryBuilder.find_command(
+                ObjectType.BOUNDING_BOX, params=find_bbox_params),
+        ]
 
         if constraints and constraints.constraints:
             find_bbox_params["constraints"] = constraints.constraints
@@ -451,7 +454,8 @@ class Images(Entities):
                         operations)
                     bboxes.append(resolved)
                     tags.append(bbox[self.bbox_label_prop])
-                    meta.append(res[0][class_entity(self.db_object) ]["entities"][0])
+                    meta.append(
+                        res[0][class_entity(self.db_object)]["entities"][0])
                     bounds.append(box)
         except Exception as e:
             logger.warn(
@@ -584,18 +588,19 @@ class Images(Entities):
 
         _, response, images = execute_query(
             self.client, query=[
-                    QueryBuilder.find_command(self.db_object, params=find_image_params)
-                ], blobs=[])
+                QueryBuilder.find_command(
+                    self.db_object, params=find_image_params)
+            ], blobs=[])
 
         entities = None
         try:
             cmd, = response[0].keys()
-            entities = response[0][ cmd ]["entities"]
+            entities = response[0][cmd]["entities"]
 
             for ent in entities:
                 self.images_ids.append(ent[self.img_id_prop])
         except Exception as e:
-            print(f"Error with search: {e}\n Response = {response}" )
+            print(f"Error with search: {e}\n Response = {response}")
 
         self.response = entities
 
@@ -651,49 +656,53 @@ class Images(Entities):
         for uniqueid in self.images_ids:
 
             find_image_params = {
-                    "_ref": 1,
-                    "constraints": {
-                        self.img_id_prop:  ["==", uniqueid]
-                    },
-                    "blobs": False,
-                }
+                "_ref": 1,
+                "constraints": {
+                    self.img_id_prop:  ["==", uniqueid]
+                },
+                "blobs": False,
+            }
             find_descriptor_params = {
-                    "set": set_name,
-                    "is_connected_to": {
-                        "ref": 1,
-                    },
-                    "blobs": True
-                }
+                "set": set_name,
+                "is_connected_to": {
+                    "ref": 1,
+                },
+                "blobs": True
+            }
 
             _, response, blobs = execute_query(self.client,
-                    [
-                    QueryBuilder.find_command(self.db_object, params=find_image_params),
-                    QueryBuilder.find_command(ObjectType.DESCRIPTOR, params=find_descriptor_params)
-                    ], [])
+                                               [
+                                                   QueryBuilder.find_command(
+                                                       self.db_object, params=find_image_params),
+                                                   QueryBuilder.find_command(
+                                                       ObjectType.DESCRIPTOR, params=find_descriptor_params)
+                                               ], [])
 
             find_descriptor_params = {
-                    "_ref": 1,
-                    "set": set_name,
-                    "k_neighbors": n_neighbors + 1,
-                    "blobs":     False,
-                    "distances": True,
-                    "uniqueids": True,
-                }
+                "_ref": 1,
+                "set": set_name,
+                "k_neighbors": n_neighbors + 1,
+                "blobs":     False,
+                "distances": True,
+                "uniqueids": True,
+            }
             find_image_params = {
-                    "is_connected_to": {
-                        "ref": 1,
-                    },
-                    "group_by_source": True,
-                    "results": {
-                        "list": [self.img_id_prop]
-                    }
+                "is_connected_to": {
+                    "ref": 1,
+                },
+                "group_by_source": True,
+                "results": {
+                    "list": [self.img_id_prop]
                 }
+            }
 
             _, response, blobs = execute_query(self.client,
-                    [
-                    QueryBuilder.find_command(ObjectType.DESCRIPTOR, params=find_descriptor_params),
-                    QueryBuilder.find_command(self.db_object, params=find_image_params)
-                    ], blobs)
+                                               [
+                                                   QueryBuilder.find_command(
+                                                       ObjectType.DESCRIPTOR, params=find_descriptor_params),
+                                                   QueryBuilder.find_command(
+                                                       self.db_object, params=find_image_params)
+                                               ], blobs)
 
             try:
                 descriptors = response[0]["FindDescriptor"]["entities"]
@@ -703,7 +712,7 @@ class Images(Entities):
                 # That's why we use "group_by_source":
                 # To have a mapping between descriptors and associated images.
                 cmd, = response[1].keys()
-                imgs_map = response[1][ cmd ]["entities"]
+                imgs_map = response[1][cmd]["entities"]
 
                 for desc_id in ordered_descs_ids:
                     img_info = imgs_map[desc_id][0]
@@ -963,23 +972,22 @@ class Images(Entities):
             for uniqueid in self.images_ids:
 
                 find_image_params = {
-                        "_ref": 1,
-                        "constraints": {
-                            self.img_id_prop: ["==", uniqueid]
-                        },
-                        "blobs": False,
-                        "results": {
-                            "list": prop_list
-                        }
+                    "_ref": 1,
+                    "constraints": {
+                        self.img_id_prop: ["==", uniqueid]
+                    },
+                    "blobs": False,
+                    "results": {
+                        "list": prop_list
                     }
+                }
 
                 _, res, images = execute_query(self.client, [
-                    QueryBuilder.find_command(self.db_object, params=find_image_params)]
-                    , [])
+                    QueryBuilder.find_command(self.db_object, params=find_image_params)], [])
 
                 cmd, = res[0].keys()
                 return_dictionary[str(
-                    uniqueid)] = res[0][ cmd ]["entities"][0]
+                    uniqueid)] = res[0][cmd]["entities"][0]
         except:
             print("Cannot retrieved properties")
 

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -688,7 +688,6 @@ class Images(Entities):
                         "list": [self.img_id_prop]
                     }
                 }
-            }]
 
             _, response, blobs = execute_query(self.client,
                     [

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -303,7 +303,6 @@ class Images(Entities):
                     "list": ["adb_image_width", "adb_image_height"]
                 },
             }
-        }
 
         find_poly_params = {
                 "image_ref": 1,

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -996,4 +996,4 @@ class Frames(Images):
 
     def __init__(self, client, batch_size=100, response=None, **kwargs):
         super().__init__(client,
-                         response, batch_size=batch_size, response=response, kwargs)
+                         response, batch_size=batch_size, response=response, **kwargs)

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -14,7 +14,7 @@ from aperturedb import Utils
 from aperturedb.Entities import Entities
 from aperturedb.Constraints import Constraints
 from aperturedb.CommonLibrary import execute_query
-from aperturedb.Query import QueryBuilder, ObjectType,class_entity
+from aperturedb.Query import QueryBuilder, ObjectType, class_entity
 from ipywidgets import widgets
 from IPython.display import display, HTML
 import base64
@@ -265,7 +265,8 @@ class Images(Entities):
 
             if self.operations and len(self.operations.operations_arr) > 0:
                 find_params["operations"] = self.operations.operations_arr
-            query.append(QueryBuilder.find_command(self.db_object, params=find_params))
+            query.append(QueryBuilder.find_command(
+                self.db_object, params=find_params))
 
         _, res, imgs = execute_query(self.client, query, [])
 
@@ -335,8 +336,10 @@ class Images(Entities):
             tags = []
             meta = []
             query = [
-                    QueryBuilder.find_command(self.db_object, params=find_image_params),
-                    QueryBuilder.find_command(ObjectType.POLYGON, params=find_poly_params)
+                    QueryBuilder.find_command(
+                        self.db_object, params=find_image_params),
+                    QueryBuilder.find_command(
+                        ObjectType.POLYGON, params=find_poly_params)
                     ]
             result, res, _ = execute_query(
                 client=self.client, query=query, blobs=[])

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -993,6 +993,7 @@ class Frames(Images):
     """
     db_object = "_Frame"
     query_object = "Frame"
+
     def __init__(self, client, batch_size=100, response=None, **kwargs):
         super().__init__(client,
-                response,batch_size=batch_size,response=response, kwargs)
+                         response, batch_size=batch_size, response=response, kwargs)

--- a/aperturedb/Query.py
+++ b/aperturedb/Query.py
@@ -50,7 +50,8 @@ config = Config.SAVE_NAME
 
 def class_entity(db_class):
     members = [m.value for m in ObjectType]
-    db_class = db_class if not isinstance(db_class, ObjectType) else db_class.value
+    db_class = db_class if not isinstance(
+        db_class, ObjectType) else db_class.value
     if db_class.startswith("_"):
         if db_class in members:
             return f"{db_class[1:]}"
@@ -435,7 +436,8 @@ class Query():
             self.blob = struct.pack("%sf" % len(self.vector), *self.vector)
 
         self.with_class = self.with_class if self.db_object == "Entity" else \
-                self.db_object if not isinstance(self.db_object, ObjectType ) else self.db_object.value
+            self.db_object if not isinstance(
+                self.db_object, ObjectType) else self.db_object.value
         cmd = QueryBuilder.find_command(
             oclass=self.with_class, params=cmd_params)
         self.find_command = list(cmd.keys())[0]

--- a/aperturedb/Query.py
+++ b/aperturedb/Query.py
@@ -47,7 +47,8 @@ class RangeType(str, Enum):
 
 config = Config.SAVE_NAME
 
-def class_entity(db_class): 
+
+def class_entity(db_class):
     members = [m.value for m in ObjectType]
     if db_class.startswith("_"):
         if oclass in members:
@@ -57,6 +58,7 @@ def class_entity(db_class):
                 f"Invalid Object type. Should not begin with _, except for {members}")
     else:
         return "Entity"
+
 
 def get_handlers():
     sources = Sources(n_download_retries=3)
@@ -273,7 +275,7 @@ class QueryBuilder():
 
     @classmethod
     def build_command(self, oclass, params, operation):
-        oclass = oclass if not isinstance(oclass,ObjectType) else oclass.value
+        oclass = oclass if not isinstance(oclass, ObjectType) else oclass.value
         command = {
             f"{operation}Entity": params
         }

--- a/aperturedb/Query.py
+++ b/aperturedb/Query.py
@@ -50,9 +50,10 @@ config = Config.SAVE_NAME
 
 def class_entity(db_class):
     members = [m.value for m in ObjectType]
+    db_class = db_class if not isinstance(db_class, ObjectType) else db_class.value
     if db_class.startswith("_"):
-        if oclass in members:
-            return f"{oclass[1:]}"
+        if db_class in members:
+            return f"{db_class[1:]}"
         else:
             raise Exception(
                 f"Invalid Object type. Should not begin with _, except for {members}")
@@ -433,7 +434,8 @@ class Query():
         if self.vector:
             self.blob = struct.pack("%sf" % len(self.vector), *self.vector)
 
-        self.with_class = self.with_class if self.db_object == "Entity" else self.db_object
+        self.with_class = self.with_class if self.db_object == "Entity" else \
+                self.db_object if not isinstance(self.db_object, ObjectType ) else self.db_object.value
         cmd = QueryBuilder.find_command(
             oclass=self.with_class, params=cmd_params)
         self.find_command = list(cmd.keys())[0]

--- a/aperturedb/Query.py
+++ b/aperturedb/Query.py
@@ -47,6 +47,16 @@ class RangeType(str, Enum):
 
 config = Config.SAVE_NAME
 
+def class_entity(db_class): 
+    members = [m.value for m in ObjectType]
+    if db_class.startswith("_"):
+        if oclass in members:
+            return f"{oclass[1:]}"
+        else:
+            raise Exception(
+                f"Invalid Object type. Should not begin with _, except for {members}")
+    else:
+        return "Entity"
 
 def get_handlers():
     sources = Sources(n_download_retries=3)
@@ -254,15 +264,16 @@ def generate_add_query(
 
 class QueryBuilder():
     @classmethod
-    def find_command(self, oclass: str, params: dict) -> dict:
+    def find_command(self, oclass: str | ObjectType, params: dict) -> dict:
         return self.build_command(oclass, params, "Find")
 
     @classmethod
-    def add_command(self, oclass: str, params: dict) -> dict:
+    def add_command(self, oclass: str | ObjectType, params: dict) -> dict:
         return self.build_command(oclass, params, "Add")
 
     @classmethod
     def build_command(self, oclass, params, operation):
+        oclass = oclass if not isinstance(oclass,ObjectType) else oclass.value
         command = {
             f"{operation}Entity": params
         }
@@ -325,6 +336,7 @@ class Query():
             p = p.next
         return chain
 
+    @classmethod
     @classmethod
     def spec(cls,
              constraints: Constraints = None,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -48,20 +48,21 @@ def pytest_generate_tests(metafunc):
     if all(func in metafunc.fixturenames for func in ["insert_data_from_csv", "modify_data_from_csv"]) and \
             metafunc.module.__name__ in ["test.test_Data"]:
         metafunc.parametrize("insert_data_from_csv,modify_data_from_csv", [
-                             pytest.param([True, True], marks=pytest.mark.dask),
+                             pytest.param(
+                                 [True, True], marks=pytest.mark.dask),
                              pytest.param([False, False])],
                              indirect=True, ids=["with_dask", "without_dask"])
     elif "insert_data_from_csv" in metafunc.fixturenames and metafunc.module.__name__ in \
             ["test.test_Data"]:
         metafunc.parametrize("insert_data_from_csv", [
-                             pytest.param( True, marks=pytest.mark.dask) ,
-                             pytest.param( False)],
-                                      indirect=True, ids=["with_dask", "without_dask"])
+                             pytest.param(True, marks=pytest.mark.dask),
+                             pytest.param(False)],
+                             indirect=True, ids=["with_dask", "without_dask"])
     elif "modify_data_from_csv" in metafunc.fixturenames and metafunc.module.__name__ in \
             ["test.test_Data"]:
         metafunc.parametrize("modify_data_from_csv", [
-                             pytest.param( True, marks=pytest.mark.dask) ,
-                             pytest.param( False )],
+                             pytest.param(True, marks=pytest.mark.dask),
+                             pytest.param(False)],
                              indirect=True, ids=["with_dask", "without_dask"])
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -48,15 +48,21 @@ def pytest_generate_tests(metafunc):
     if all(func in metafunc.fixturenames for func in ["insert_data_from_csv", "modify_data_from_csv"]) and \
             metafunc.module.__name__ in ["test.test_Data"]:
         metafunc.parametrize("insert_data_from_csv,modify_data_from_csv", [
-                             [True, True], [False, False]], indirect=True, ids=["with_dask", "without_dask"])
+                             pytest.param([True, True], marks=pytest.mark.dask),
+                             pytest.param([False, False])],
+                             indirect=True, ids=["with_dask", "without_dask"])
     elif "insert_data_from_csv" in metafunc.fixturenames and metafunc.module.__name__ in \
             ["test.test_Data"]:
         metafunc.parametrize("insert_data_from_csv", [
-                             True, False], indirect=True, ids=["with_dask", "without_dask"])
+                             pytest.param( True, marks=pytest.mark.dask) ,
+                             pytest.param( False)],
+                                      indirect=True, ids=["with_dask", "without_dask"])
     elif "modify_data_from_csv" in metafunc.fixturenames and metafunc.module.__name__ in \
             ["test.test_Data"]:
         metafunc.parametrize("modify_data_from_csv", [
-                             True, False], indirect=True, ids=["with_dask", "without_dask"])
+                             pytest.param( True, marks=pytest.mark.dask) ,
+                             pytest.param( False )],
+                             indirect=True, ids=["with_dask", "without_dask"])
 
 
 @pytest.fixture()

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -8,4 +8,5 @@ markers =
 	remote_credentials: mark a test as requiring remote authentication ( that isn't included in checkout )
 	kaggle: uses kaggle
 	http: uses HTTP/HTTPS interface
-	tcp: ues TCP/REST interface
+	tcp: uses TCP/REST interface
+    dask: uses DASK multi-processing library


### PR DESCRIPTION
Modifies Images to support Frames, based on usage pattern from https://github.com/drewaogle/YOLOv4-OpenCV-CUDA-DNN/blob/main/VideoClips.ipynb which aimed to use `Images`, but on frame objects.

