### PR TITLE
pypi does not accept artifact with github based dependencies.

### DIFF
--- a/docker/tests/Dockerfile
+++ b/docker/tests/Dockerfile
@@ -6,6 +6,7 @@ ADD docker/tests/aperturedata /aperturedata
 
 RUN pip install awscli
 RUN cd /aperturedata && pip install -e ".[dev]"
+RUN pip install git+https://github.com/openai/CLIP.git
 COPY docker/tests/scripts/start.sh /start.sh
 RUN  chmod 755 /start.sh
 CMD ["/start.sh"]

--- a/publish.sh
+++ b/publish.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "Building aperturedb"
 rm -rf build/ dist/ vdms.egg-info/
 python3 -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ dev = [
     "pytest",
     "build",
     "fuse-python ; platform_system == 'Linux'",
-    "clip@git+https://github.com/openai/CLIP.git@dcba3cb2e2827b402d2701e7e1c7d9fed8a20ef1", 
     "rdflib",
 ]
 


### PR DESCRIPTION
A recently undedected failure happened while publishing 0.4.37 https://github.com/aperture-data/aperturedb-python/actions/runs/11728588500/job/32675080673#step:6:555