### PR TITLE
add known hosts verification

### DIFF
--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -118,8 +118,6 @@ class Connector(object):
 
 
     Some parameters are mainly of use when copying the object. `shared_data` and `authenticate` are designed for this.
-
-    
     """
 
     def __init__(self, host="localhost", port=55555,

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -36,7 +36,7 @@ import json
 import ssl
 import logging
 import fnmatch
-from enum import Enum,auto
+from enum import Enum, auto
 from datetime import datetime, timedelta
 
 import keepalive
@@ -80,6 +80,7 @@ class Session():
 
         return True
 
+
 class VerifyType(Enum):
     NONE = auto()
     KNOWN_HOSTS = auto()
@@ -87,7 +88,7 @@ class VerifyType(Enum):
 
 
 class Connector(object):
-    default_known_hosts = [ "*.aperturedata.io" ]
+    default_known_hosts = ["*.aperturedata.io"]
     """
     **Class to facilitate connections with an instance of ApertureDB**
 
@@ -179,20 +180,20 @@ class Connector(object):
             self.shared_data = shared_data
 
         self.verify_type = verify_ssl
-        self.verify_names = self.default_known_hosts 
-        self.should_authenticate = authenticate 
+        self.verify_names = self.default_known_hosts
+        self.should_authenticate = authenticate
         # One time flag to indicate if we ever connected,
         # to prevent logging of connection errors on first connect.
         self._ever_connected = False
 
     @classmethod
-    def set_default_known_hosts( cls, new_hosts: List[str] ):
+    def set_default_known_hosts(cls, new_hosts: List[str]):
         cls.default_known_hosts = new_hosts
 
-    def set_known_hosts( self, new_hosts: List[str] ):
+    def set_known_hosts(self, new_hosts: List[str]):
         self.verify_names = new_hosts
 
-    def get_known_hosts( self ): 
+    def get_known_hosts(self):
         return self.verify_names
 
     def authenticate(self, shared_data, user, password, token):
@@ -372,16 +373,16 @@ class Connector(object):
                         lambda h: fnmatch.fnmatch(self.host, h), self.verify_names))
 
                 self.context.verify_mode = \
-                        ssl.VerifyMode.CERT_REQUIRED if check_cert else ssl.VerifyMode.CERT_NONE
+                    ssl.VerifyMode.CERT_REQUIRED if check_cert else ssl.VerifyMode.CERT_NONE
 
                 if check_cert:
                     if not 'ADB_SSL_CA_FILE' in os.environ:
                         self.context.load_default_certs()
                     else:
-                        self.context.load_verify_locations(cafile=os.environ['ADB_SSL_CA_FILE'])
+                        self.context.load_verify_locations(
+                            cafile=os.environ['ADB_SSL_CA_FILE'])
 
                 self.conn = self.context.wrap_socket(self.conn)
-
 
         except BaseException as e:
             self.conn.close()

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -106,8 +106,8 @@ class Connector(object):
         str (password): Password to specify while connecting to ApertureDB.
         str (token): Token to use while connecting to the database.
         bool (use_ssl): Use SSL to encrypt communication with the database.
-        bool (authenticate): If connection needs to authenticate
-        object (shared_data): If connection needs to authenticate
+        bool (authenticate): Whether connection needs to authenticate
+        object (shared_data): Passed in authentication data ( for when authenticate is no )
         VerifyType (verify_ssl): Rule for verifying a SSL connection
         bool (use_keepalive): Set keepalive on the connection with the database.
             This has two benefits: It reduces the chance of disconnection for a long-running query,
@@ -375,15 +375,12 @@ class Connector(object):
                         ssl.VerifyMode.CERT_REQUIRED if check_cert else ssl.VerifyMode.CERT_NONE
 
                 if check_cert:
-                    print("Check")
                     if not 'ADB_SSL_CA_FILE' in os.environ:
                         self.context.load_default_certs()
                     else:
                         self.context.load_verify_locations(cafile=os.environ['ADB_SSL_CA_FILE'])
-                else:
-                    print("No Check")
-                self.conn = self.context.wrap_socket(self.conn)
 
+                self.conn = self.context.wrap_socket(self.conn)
 
 
         except BaseException as e:


### PR DESCRIPTION
- Adds `VerifyType` to control how verification is done.
- sets `VerifyType.KNOWN_HOSTS` as the default action
- sets "*.aperturedata.io" as the known hosts.
- adds accessors for manipulating the known host list.
- adds `ADB_SSL_CA_FILE` as an environment variable usable for passing in a pem file for verification.