### PR TITLE
Fix logging on Win32

### DIFF
--- a/aperturedb/__init__.py
+++ b/aperturedb/__init__.py
@@ -37,7 +37,7 @@ if error_file_name is not None:
     error_file_tmpl = Template(error_file_name)
     template_items = {
         # python isodate has ':', not valid in files in windows.
-        "now": str(datetime.datetime.now().isoformat()).replace(':',''),
+        "now": str(datetime.datetime.now().isoformat()).replace(':', ''),
         "node": str(platform.node())
     }
     error_file_handler = logging.FileHandler(error_file_tmpl.safe_substitute(

--- a/aperturedb/__init__.py
+++ b/aperturedb/__init__.py
@@ -36,7 +36,8 @@ if "ADB_LOG_FILE" in os.environ:
 if error_file_name is not None:
     error_file_tmpl = Template(error_file_name)
     template_items = {
-        "now": str(datetime.datetime.now().isoformat()),
+        # python isodate has ':', not valid in files in windows.
+        "now": str(datetime.datetime.now().isoformat()).replace(':',''),
         "node": str(platform.node())
     }
     error_file_handler = logging.FileHandler(error_file_tmpl.safe_substitute(


### PR DESCRIPTION
Fixes #544 

Simply removed ':' from default `now` filename substitution, removing the item win32 doesn't like in files.

@bovlb mentioned without the ':' is a valid iso date, this is slightly less user readable, but I don't think users are extremely concerned about reading