### PR TITLE
Check content length of image matches the content-length header

### DIFF
--- a/aperturedb/Sources.py
+++ b/aperturedb/Sources.py
@@ -45,7 +45,7 @@ class Sources():
         retries = 0
         while True:
             imgdata = self.http_client.get(url)
-            if imgdata.ok:
+            if imgdata.ok and ("Content-Length" not in imgdata.headers or int(imgdata.headers["Content-Length"]) == imgdata.raw._fp_bytes_read):
                 imgbuffer = np.frombuffer(imgdata.content, dtype='uint8')
                 if not validator(imgbuffer):
                     logger.error(f"VALIDATION ERROR: {url}")


### PR DESCRIPTION
When downloading images or videos, sometimes content is not received completely and the `requests` library doesn't reflect any error. Comparing `Content-Length` header with the size of received content will tell us if content was downloaded completely or no.