### PR TITLE
Add helpful errors for using a filtered DataFrame

### DIFF
--- a/aperturedb/CSVParser.py
+++ b/aperturedb/CSVParser.py
@@ -62,6 +62,10 @@ class CSVParser(Subscriptable):
                 self.df = pd.read_csv(filename)
             else:
                 self.df = df
+
+                if not hasattr( self.df.index, "start" ):
+                    raise ValueError("Supplied Dataframe's index missing 'start'" +
+                        "(Probably a filtered DataFrame - try reset_index )")
         else:
             # It'll impact the number of partitions, and memory usage.
             # TODO: tune this for the best performance.

--- a/aperturedb/CSVParser.py
+++ b/aperturedb/CSVParser.py
@@ -63,9 +63,9 @@ class CSVParser(Subscriptable):
             else:
                 self.df = df
 
-                if not hasattr( self.df.index, "start" ):
+                if not hasattr(self.df.index, "start"):
                     raise ValueError("Supplied Dataframe's index missing 'start'" +
-                        "(Probably a filtered DataFrame - try reset_index )")
+                                     "(Probably a filtered DataFrame - try reset_index )")
         else:
             # It'll impact the number of partitions, and memory usage.
             # TODO: tune this for the best performance.

--- a/aperturedb/ImageDataCSV.py
+++ b/aperturedb/ImageDataCSV.py
@@ -245,7 +245,7 @@ class ImageDataCSV(CSVParser.CSVParser, ImageDataProcessor):
             allowed = ", ".join(self.source_types)
             if self.header[0] == 'index' and self.header[1] in self.source_types:
                 raise Exception(f"Error with CSV: 'index' is first column" +
-                    "please drop('index') to use")
+                                "please drop('index') to use")
             else:
                 raise Exception(
                     f"Error with CSV file field: {field}. Allowed values: {allowed}")

--- a/aperturedb/ImageDataCSV.py
+++ b/aperturedb/ImageDataCSV.py
@@ -243,8 +243,12 @@ class ImageDataCSV(CSVParser.CSVParser, ImageDataProcessor):
         if self.header[0] not in self.source_types:
             field = self.header[0]
             allowed = ", ".join(self.source_types)
-            raise Exception(
-                f"Error with CSV file field: {field}. Allowed values: {allowed}")
+            if self.header[0] == 'index' and self.header[1] in self.source_types:
+                raise Exception(f"Error with CSV: 'index' is first column" +
+                    "please drop('index') to use")
+            else:
+                raise Exception(
+                    f"Error with CSV file field: {field}. Allowed values: {allowed}")
 
 
 class ImageUpdateDataCSV(SingleEntityUpdateDataCSV, ImageDataProcessor):


### PR DESCRIPTION
I have a dataframe I'm passing to ImageDataCSV, and it isn't happy for two reasons:

- CSVParser wants to use `RangeIndex.start` which doesn't exist on a filtered DataFrame.
- Then if you do reset_index, by default it then adds `index` which makes ImageDataCSV unhappy.


This PR simply tests for those conditions and gives a helpful error.
We may want to also add this to documentation. I don't think we want to attempt to correct inside the code because the supplied dataframes may be large.