### PR TITLE
Remove debugging logs for cli ingest.py

### DIFF
--- a/aperturedb/cli/ingest.py
+++ b/aperturedb/cli/ingest.py
@@ -130,8 +130,6 @@ def from_generator(filepath: Annotated[str, typer.Argument(
         all_transformers = transformer + user_transformer
         data = _apply_pipeline(data, all_transformers,
                                adb_data_source=f"{module_name}.{mclass.__name__}")
-    else:
-        console.log("No transformer applied")
 
     if debug:
         _debug_samples(data, sample_count, module_name)
@@ -209,10 +207,8 @@ def from_csv(filepath: Annotated[str, typer.Argument(
         all_transformers = transformer + user_transformer
         data = _apply_pipeline(data, all_transformers,
                                adb_data_source=f"{ingest_type}.{os.path.basename(filepath)}")
-    else:
-        console.log("No transformer applied")
+
     client = create_connector()
-    console.log(client)
 
     loader = ParallelLoader(client)
     if debug:


### PR DESCRIPTION
Removes the last 3 lines in the example below, which seem unnecessary on default logging configuration:

```
Progress: 100.00% - ETA(s): 0.00
============ ApertureDB Loader Stats ============
Total time (s): 134.3380880355835
Total queries executed: 1184
Avg Query time (s): 0.8870820974981463
Query time std: 0.18877949737167854
Avg Query Throughput (q/s): 9.018331023208049
Overall insertion throughput (element/s): 880.517221360692
Total inserted elements: 118287
Total successful commands: 354861
=================================================
adb ingest from-csv /app/input/train_images.adb.csv_clip_pytorch_embeddings_metadata.adb.csv --ingest-type DESCRIPTOR --batchsize 100 --num-workers 8 --no-use-dask --sample-count -1 --stats
[17:32:14] No transformer applied                                  ingest.py:213
           <aperturedb.Connector.Connector object at               ingest.py:215
           0x7f66c88fbfa0>
```