### PR TITLE
Fix adb utils execute status

### DIFF
--- a/aperturedb/cli/utilities.py
+++ b/aperturedb/cli/utilities.py
@@ -36,7 +36,7 @@ def execute(command: CommandTypes,
 
     utils = Utils(create_connector())
     available_commands = {
-        CommandTypes.STATUS: lambda: print(utils),
+        CommandTypes.STATUS: lambda: print(utils.status()),
         CommandTypes.SUMMARY: utils.summary,
         CommandTypes.REMOVE_ALL: lambda: confirm(
             CommandTypes.REMOVE_ALL, force) and utils.remove_all_objects(),


### PR DESCRIPTION
Fix #557 

```
❯ adb utils execute status
[
    {
        "GetStatus": {
            "info": "OK",
            "status": 0,
            "system": "ApertureDB",
            "version": "0.18.8"
        }
    }
]
```