### PR TITLE
Run twine from container, without apt get. (#559)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,10 +69,6 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        apt-get update
-        apt-get install -y python3.10-venv
-        pip3 install build
-        pip3 install twine
         bash publish.sh
 
     - name: Tag release version

--- a/aperturedb/__init__.py
+++ b/aperturedb/__init__.py
@@ -16,7 +16,7 @@ faulthandler.register(signal.SIGUSR1.value)
 
 logger = logging.getLogger(__name__)
 
-__version__ = "0.4.40"
+__version__ = "0.4.42"
 
 # set log level
 formatter = logging.Formatter(

--- a/docker/twine/Dockerfile
+++ b/docker/twine/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.10
+
+RUN pip install twine

--- a/publish.sh
+++ b/publish.sh
@@ -4,8 +4,13 @@ echo "Building aperturedb"
 rm -rf build/ dist/ vdms.egg-info/
 python3 -m build
 
+docker build --no-cache -t CI/twine -f docker/twine/Dockerfile .
 echo "Uploading aperturedb"
-twine upload --skip-existing --verbose dist/*
+docker run --name publisher \
+  -e "TWINE_USERNAME=${TWINE_USERNAME}" \
+  -e "TWINE_PASSWORD=${TWINE_PASSWORD}" \
+  -v ./dist:/dist \
+  CI/twine twine upload --skip-existing --verbose dist/*
 
 RELEASE_IMAGE="aperturedata/aperturedb-python:latest"
 source version.sh && read_version


### PR DESCRIPTION
Unblock the publish step.