### PR TITLE
Fix stacktrace invocation making import impossible in windows

### DIFF
--- a/aperturedb/__init__.py
+++ b/aperturedb/__init__.py
@@ -8,15 +8,21 @@ from string import Template
 import platform
 import faulthandler
 import signal
+import sys
+
+__version__ = "0.4.43"
+
+logger = logging.getLogger(__name__)
 
 # https://docs.python.org/3/library/faulthandler.html
 # Register SIGUSR1 to dump the stack trace
 # Good for debugging a running process
-faulthandler.register(signal.SIGUSR1.value)
 
-logger = logging.getLogger(__name__)
-
-__version__ = "0.4.43"
+if os.getenv("ADB_DEBUGGABLE", None) != None: 
+    if sys.platform == "win32":
+        logger.warn("Unable to configure debugging support for win32")
+    else:
+        faulthandler.register(signal.SIGUSR1.value)
 
 # set log level
 formatter = logging.Formatter(

--- a/aperturedb/__init__.py
+++ b/aperturedb/__init__.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 # Register SIGUSR1 to dump the stack trace
 # Good for debugging a running process
 
-if os.getenv("ADB_DEBUGGABLE", None) != None: 
+if os.getenv("ADB_DEBUGGABLE", None) != None:
     if sys.platform == "win32":
         logger.warn("Unable to configure debugging support for win32")
     else:


### PR DESCRIPTION
user on ApertureDB slack reported issue.

https://docs.python.org/3/library/faulthandler.html#dumping-the-traceback-on-a-user-signal

`register` is not available on windows; it will simply throw an error if you try to sue it.