### PR TITLE
remove grpcio-status pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ dependencies = [
     'matplotlib', 'pandas', 'kaggle!=1.6.15', 'google-cloud-storage',
     'ipython', 'dask[complete]', 'ipywidgets', 'pydantic>=2.6.0', 'devtools', 'typer',
     "opencv-python-headless",
-    # Pinning this to be able to install google-cloud-bigquery
-    'grpcio-status==1.48.2',
     # Pinning this to resolve test errors temporarily
     'ipywidgets==8.0.4',
     'keepalive-socket==0.0.1',


### PR DESCRIPTION
it appears that grpcio-status was pinned to aid in installing `google-cloude-bigquery`

however now:
```
python3 -m venv ./bqtest
./bqtest/bin/activate
pip install -e .
pip install google-cloud-bigquery
```

works fine.

Results are:
```
(bq_test) drew@Dunstan:/code/aperture/aperturedb-python$ pip list | grep grpc
grpcio                   1.71.0
grpcio-status            1.71.0
```

versus old:
```
(adb_testing) drew@Dunstan:~$ pip list | grep grpc
grpcio                    1.63.0
grpcio-status             1.48.2
```

so it looks like a newer gprc can be used as well.