### PR TITLE
bump up pre commit version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,8 +18,6 @@ jobs:
       with:
         python-version: '3.10'
 
-    - uses: pre-commit/action@v2.0.3
-
-    - uses: actions/checkout@v3
+    - uses: pre-commit/action@v3.0.1
 
     - uses: luisremis/find-trailing-whitespace@master


### PR DESCRIPTION
This unblocks all the failing CI runs.
Note the error message : https://github.com/aperture-data/aperturedb-python/actions/runs/14339506382/job/40195048106?pr=581