### PR TITLE
Adds a class that can iterate over Croissant datasets and generate queries to persist them to ApertureDB.

### DIFF
--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -315,7 +315,7 @@ def execute_query(client: Connector, query: Commands,
                     warn_list.append(wr)
         if len(warn_list) != 0:
             logger.warning(
-                f"Partial errors:\r\n{json.dumps(query)}\r\n{json.dumps(warn_list)}")
+                f"Partial errors:\r\n{json.dumps(query, default=str)}\r\n{json.dumps(warn_list, default=str)}")
             result = 2
 
     return result, r, b

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -376,7 +376,7 @@ class Connector(object):
         response_blob_array = []
         # Check the query type
         if not isinstance(query, str):  # assumes json
-            query_str = json.dumps(query)
+            query_str = json.dumps(query, default=str)
         else:
             query_str = query
 

--- a/aperturedb/ConnectorRest.py
+++ b/aperturedb/ConnectorRest.py
@@ -77,7 +77,10 @@ class ConnectorRest(Connector):
         # A Convenience feature to not require the port
         # Relies on common ports for http and https, but can be overriden
         if port is None:
-            self.port = 443 if use_ssl else 80
+            if config is None:
+                self.port = 443 if use_ssl else 80
+            else:
+                self.port = config.port
         else:
             self.port = port
 

--- a/aperturedb/EntityUpdateDataCSV.py
+++ b/aperturedb/EntityUpdateDataCSV.py
@@ -25,9 +25,9 @@ class SingleEntityUpdateDataCSV(CSVParser.CSVParser):
        - a series of updateif_ to determine if an update is necessary
 
        Conditionals:
-         updateif>_prop - updates if the database value > csv value
-         updateif<_prop - updates if the database value < csv value
-         updateif!_prop - updates if the database value is != csv value
+         ```updateif>_prop``` : updates if the database value greater than csv value
+         ```updateif<_prop``` : updates if the database value less than csv value
+         ```updateif!_prop``` : updates if the database value is not equal to csv value
 
     :::note
     Is backed by a CSV file with the following columns (format optional):

--- a/aperturedb/MLCroissant.py
+++ b/aperturedb/MLCroissant.py
@@ -1,6 +1,6 @@
 import io
 import json
-from typing import Any, List
+from typing import Any, List, Tuple
 
 import PIL
 import PIL.Image
@@ -34,6 +34,14 @@ class DatasetModel(IdentityDataModel):
 
 
 def deserialize_record(record):
+    """These are the types of records that we expect to deserialize, from croissant Records.
+
+    Args:
+        record (_type_): _description_
+
+    Returns:
+        _type_: _description_
+    """
     deserialized = record
     if record is None:
         deserialized = "Not Available"
@@ -48,10 +56,16 @@ def deserialize_record(record):
             deserialized = json.loads(deserialized)
         except:
             pass
+    if isinstance(deserialized, list):
+        deserialized = [deserialize_record(item) for item in deserialized]
+    if isinstance(deserialized, dict):
+        deserialized = {k: deserialize_record(
+            v) for k, v in deserialized.items()}
+
     return deserialized
 
 
-def persist_metadata(client, dataset: mlc.Dataset) -> DatasetModel:
+def persist_metadata(dataset: mlc.Dataset) -> Tuple[List[dict], List[bytes]]:
 
     ds = DatasetModel(
         name=dataset.metadata.name,
@@ -65,16 +79,14 @@ def persist_metadata(client, dataset: mlc.Dataset) -> DatasetModel:
     )
     q, b, _ = generate_add_query(ds)
 
-    result, response, blobs = execute_query(
-        client, q, b, success_statuses=[0, 2])
-    assert result == 0, response
-    return ds
+    return q, b
 
 
 def dict_to_query(row_dict, name: str, flatten_json: bool) -> Any:
     literals = {}
     subitems = {}
     blobs = {}
+    o_literalse = {}
 
     # If name is not specified, or begins with _, this enures that it
     # complies with the ApertureDB naming conventions
@@ -91,15 +103,17 @@ def dict_to_query(row_dict, name: str, flatten_json: bool) -> Any:
 
         record = deserialize_record(item)
         if flatten_json and isinstance(record, list):
-            subitems[k] = str(record)
+            subitems[k] = record
         else:
-            literals[k] = str(record)
+            literals[k] = record
+            o_literalse[k] = item
 
     if flatten_json:
         str_rep = "".join([f"{str(k)}{str(v)}" for k, v in literals.items()])
         literals["adb_uuid"] = hashlib.sha256(
             str_rep.encode('utf-8')).hexdigest()
 
+    literals["adb_class_name"] = name
     q = QueryBuilder.add_command(name, {
         "properties": literals,
     })
@@ -140,9 +154,18 @@ def dict_to_query(row_dict, name: str, flatten_json: bool) -> Any:
 
 
 class MLCroissantRecordSet(Subscriptable):
-    def __init__(self, record_set: mlc.RecordSet, name: str, flatten_json: bool):
+    def __init__(self, record_set: mlc.RecordSet, name: str, flatten_json: bool, sample_count: int = 0):
         self.record_set = record_set
-        self.df = pd.DataFrame(record_set)
+        samples = []
+        count = 0
+        for record in record_set:
+            samples.append({k: v for k, v in record.items()})
+            count += 1
+            if count == sample_count:
+                break
+
+        self.df = pd.json_normalize(samples)
+        self.sample_count = len(samples)
         self.name = name
         self.flatten_json = flatten_json
         self.indexed_entities = set()

--- a/aperturedb/MLCroissant.py
+++ b/aperturedb/MLCroissant.py
@@ -1,0 +1,174 @@
+import io
+import json
+from typing import Any, List
+
+import PIL
+import PIL.Image
+import mlcroissant as mlc
+import pandas as pd
+
+
+from aperturedb.Subscriptable import Subscriptable
+from aperturedb.ParallelLoader import ParallelLoader
+from aperturedb.Query import QueryBuilder
+from aperturedb.CommonLibrary import (
+    create_connector
+)
+from aperturedb.CommonLibrary import execute_query
+
+
+import dataclasses
+from typer import Typer
+import hashlib
+
+from aperturedb.DataModels import IdentityDataModel
+from aperturedb.Query import generate_add_query
+
+
+class RecordSetModel(IdentityDataModel):
+    name: str
+    description: str = ""
+    uuid: str = ""
+
+
+class DatasetModel(IdentityDataModel):
+    name: str = "Croissant Dataset automatically ingested into ApertureDB"
+    description: str = f"A dataset loaded from a croissant json-ld"
+    version: str = "1.0.0"
+    record_sets: List[RecordSetModel] = dataclasses.field(default_factory=list)
+
+
+def deserialize_record(record):
+    deserialized = record
+    if record is None:
+        deserialized = "Not Available"
+    if isinstance(record, bytes):
+        deserialized = record.decode('utf-8')
+    if isinstance(record, pd.Timestamp):
+        deserialized = {"_date": record.to_pydatetime().isoformat()}
+    if record == pd.NaT:
+        deserialized = "Not Available Time"
+    if isinstance(deserialized, str):
+        try:
+            deserialized = json.loads(deserialized)
+        except:
+            pass
+    return deserialized
+
+
+def persist_metadata(client, dataset: mlc.Dataset) -> DatasetModel:
+
+    ds = DatasetModel(
+        name=dataset.metadata.name,
+        description=dataset.metadata.description,
+        version=dataset.metadata.version or "1.0.0",
+        record_sets=[RecordSetModel(
+            name=rs.name,
+            description=rs.description,
+            uuid=rs.uuid,
+        ) for rs in dataset.metadata.record_sets]
+    )
+    q, b, _ = generate_add_query(ds)
+
+    result, response, blobs = execute_query(
+        client, q, b, success_statuses=[0, 2])
+    assert result == 0, response
+    return ds
+
+
+def dict_to_query(row_dict, name: str, flatten_json: bool) -> Any:
+    literals = {}
+    subitems = {}
+    blobs = {}
+    for k, v in row_dict.items():
+        item = v
+        if isinstance(item, PIL.Image.Image):
+            # item = item.convert("RGB")
+            buffer = io.BytesIO()
+            item.save(buffer, format=item.format)
+            blobs[k] = buffer.getvalue()
+            continue
+
+        record = deserialize_record(item)
+        if flatten_json and isinstance(record, list):
+            subitems[k] = str(record)
+        else:
+            literals[k] = str(record)
+
+    if flatten_json:
+        str_rep = "".join([f"{str(k)}{str(v)}" for k, v in literals.items()])
+        literals["adb_uuid"] = hashlib.sha256(
+            str_rep.encode('utf-8')).hexdigest()
+
+    q = QueryBuilder.add_command(name or "Record", {
+        "properties": literals,
+    })
+    if flatten_json:
+        q[list(q.keys())[-1]]["if_not_found"] = {
+            "adb_uuid": ["==", literals["adb_uuid"]]
+        }
+
+    dependents = []
+    if len(subitems) > 0 or len(blobs) > 0:
+        q[list(q.keys())[-1]]["_ref"] = 1
+
+    for key in subitems:
+        for item in subitems[key]:
+            subitem_query = dict_to_query(item, f"{name}.{key}", flatten_json)
+            subitem_query[0][list(subitem_query[0].keys())[-1]]["connect"] = {
+                "ref": 1,
+                "class": key,
+                "direction": "out",
+            }
+            dependents.extend(subitem_query)
+
+    from aperturedb.Query import ObjectType
+    image_blobs = []
+    for blob in blobs:
+        image_query = QueryBuilder.add_command(ObjectType.IMAGE, {
+            "properties": literals,
+            "connect": {
+                "ref": 1,
+                "class": blob,
+                "direction": "out"
+            }
+        })
+        image_blobs.append(blobs[blob])
+        dependents.append(image_query)
+
+    return [q] + dependents, image_blobs
+
+
+class MLCroissantRecordSet(Subscriptable):
+    def __init__(self, record_set: mlc.RecordSet, name: str, flatten_json: bool):
+        self.record_set = record_set
+        self.df = pd.DataFrame(record_set)
+        self.name = name
+        self.flatten_json = flatten_json
+        self.indexed_entities = set()
+
+    def getitem(self, subscript):
+        row = self.df.iloc[subscript]
+        # Convert the row to a dictionary
+        row_dict = row.to_dict()
+
+        q, blobs = dict_to_query(row_dict, self.name, self.flatten_json)
+        indexes_to_create = []
+        for command in q:
+            cmd = list(command.keys())[-1]
+            if cmd == "AddImage":
+                continue
+            indexable_entity = command[list(command.keys())[-1]]["class"]
+            if indexable_entity not in self.indexed_entities:
+                index_command = {
+                    "CreateIndex": {
+                        "class": indexable_entity,
+                        "index_type": "entity",
+                        "property_key": "adb_uuid",
+                    }
+                }
+                indexes_to_create.append(index_command)
+        return indexes_to_create + q, blobs
+
+    def __len__(self):
+        return len(self.df)

--- a/aperturedb/cli/ingest.py
+++ b/aperturedb/cli/ingest.py
@@ -42,7 +42,7 @@ def _debug_samples(data, sample_count, module_name):
         with open(module_name + f"_{i}" + ".raw", "w") as f:
             f.write(str(query))
         with open(module_name + f"_{i}" + ".json", "w") as f:
-            f.write(json.dumps(query, indent=2, default=str))
+            json.dump(query, f, indent=2, ensure_ascii=False)
         for j, blob in enumerate(blobs):
             with open(module_name + f"_{i}_{j}" + ".jpg", "wb") as f:
                 f.write(blob)
@@ -291,7 +291,7 @@ def from_croissant(
         _process_data(
             data,
             sample_count=actual_sample_count,
-            module_name=record_set.name or "record",
+            module_name=record_set.name or record_set.uuid,
             batchsize=batchsize,
             num_workers=num_workers,
             stats=stats,

--- a/aperturedb/cli/ingest.py
+++ b/aperturedb/cli/ingest.py
@@ -282,9 +282,10 @@ def from_croissant(
         actual_sample_count = len(data) if sample_count == -1 else sample_count
         data = MLCroissantRecordSet(
             croissant_dataset.records(record_set=record_set.uuid),
-            name=record_set.name,
+            name=record_set.name or record_set.uuid,
             flatten_json=flatten_json,
-            sample_count=actual_sample_count
+            sample_count=actual_sample_count,
+            uuid=record_set.uuid
         )
 
         _process_data(

--- a/aperturedb/cli/ingest.py
+++ b/aperturedb/cli/ingest.py
@@ -279,15 +279,15 @@ def from_croissant(
     for record_set in croissant_dataset.metadata.record_sets:
         console.log(
             f"Record Set: {record_set.name} ({record_set.uuid}) with {sample_count} samples")
-        actual_sample_count = len(data) if sample_count == -1 else sample_count
+
         data = MLCroissantRecordSet(
             croissant_dataset.records(record_set=record_set.uuid),
             name=record_set.name or record_set.uuid,
             flatten_json=flatten_json,
-            sample_count=actual_sample_count,
+            sample_count=sample_count,
             uuid=record_set.uuid
         )
-
+        actual_sample_count = len(data)
         _process_data(
             data,
             sample_count=actual_sample_count,

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -2,6 +2,7 @@
 
 set -u
 set -e
+set -o pipefail
 
 mkdir -p output
 rm -rf output/*

--- a/test/test_CLI.py
+++ b/test/test_CLI.py
@@ -32,7 +32,7 @@ class TestConfigure():
         with patch.multiple(typer,
                             get_app_dir=MagicMock(return_value=fake_folder)):
             runner = CliRunner()
-            result = runner.invoke(app, ["create", "test"])
+            result = runner.invoke(app, ["create", "test", "--no-interactive"])
             assert result.exit_code == 0
             self.check_contents(fake_file, None, "test")
 
@@ -45,7 +45,8 @@ class TestConfigure():
         with patch.multiple(os,
                             getcwd=MagicMock(return_value=fake_folder)):
             runner = CliRunner()
-            result = runner.invoke(app, ["create", "test", "--no-as-global"])
+            result = runner.invoke(
+                app, ["create", "test", "--no-as-global", "--no-interactive"])
             assert result.exit_code == 0
             self.check_contents(fake_file, None, "test")
 
@@ -56,7 +57,8 @@ class TestConfigure():
             with patch.multiple(typer,
                                 get_app_dir=MagicMock(return_value=fake_folder)):
                 runner = CliRunner()
-                result = runner.invoke(app, ["create", "test"])
+                result = runner.invoke(
+                    app, ["create", "test", "--no-interactive"])
                 assert result.exit_code == 0
                 self.check_contents(fake_file, None, "test")
 
@@ -104,7 +106,7 @@ class TestConfigure():
                                 getcwd=MagicMock(return_value=fake_folder)):
                 runner = CliRunner()
                 result = runner.invoke(
-                    app, ["create", "test", "--no-as-global"])
+                    app, ["create", "test", "--no-as-global", "--no-interactive"])
                 assert result.exit_code == 0
                 self.check_contents(fake_file, None, "test")
 
@@ -117,7 +119,8 @@ class TestConfigure():
             with patch.multiple(typer,
                                 get_app_dir=MagicMock(return_value=fake_folder)):
                 runner = CliRunner()
-                result = runner.invoke(app, ["create", "test"])
+                result = runner.invoke(
+                    app, ["create", "test", "--no-interactive"])
                 assert result.exit_code == 0
                 self.check_contents(fake_file, None, "test")
 
@@ -132,7 +135,7 @@ class TestConfigure():
                                 getcwd=MagicMock(return_value=fake_folder)):
                 runner = CliRunner()
                 result = runner.invoke(
-                    app, ["create", "test", "--no-as-global"])
+                    app, ["create", "test", "--no-as-global", "--no-interactive"])
                 assert result.exit_code == 0
                 self.check_contents(fake_file, None, "test")
 


### PR DESCRIPTION
This can be invoked as follows:
For a dry run (all the generated queries in files in cwd):
```
adb ingest from-croissant https://huggingface.co/api/datasets/FreedomIntelligence/PubMedVision/croissant --sample-count 1 --debug
adb ingest from-croissant https://huggingface.co/api/datasets/Rapidata/text-2-video-human-preferences-veo3/croissant --sample-count 1 --debug
adb ingest from-croissant https://huggingface.co/api/datasets/MathLLMs/MathVision/croissant --sample-count 1 --debug
```

Without the trailing --debug to actually run these queries on ApertureDB.

TODO:
- [ ] URL resolution
- [ ] Flattening of nested JSON into connected entities.
- [ ] Avoid intermediate parse into a Dataframe.