### PR TITLE
Small fixes to CSV df and Configuration token

### DIFF
--- a/aperturedb/CSVParser.py
+++ b/aperturedb/CSVParser.py
@@ -76,6 +76,11 @@ class CSVParser(Subscriptable):
                 self.filename,
                 blocksize=blocksize)
 
+        # we expect the df index to have 'start', which means RangeIndex.
+        # most users don't supply their own df, so this is mostly a sanity check
+        # for when an advanced user has done filtering and have a IntervalIndex.
+        if not isinstance(self.df.index,pd.RangeIndex):
+            raise Exception(f"CSVParser requires a RangeIndex. the supplied DataFrame has a type(self.df.index) index.")
         # len for dask dataframe needs a client.
         if not self.use_dask and len(self.df) == 0:
             logger.error("Dataframe empty. Is the CSV file ok?")

--- a/aperturedb/CSVParser.py
+++ b/aperturedb/CSVParser.py
@@ -80,7 +80,7 @@ class CSVParser(Subscriptable):
         # most users don't supply their own df, so this is mostly a sanity check
         # for when an advanced user has done filtering and have a IntervalIndex.
         if not isinstance(self.df.index,pd.RangeIndex):
-            raise Exception(f"CSVParser requires a RangeIndex. the supplied DataFrame has a type(self.df.index) index.")
+            raise Exception(f"CSVParser requires a RangeIndex. the supplied DataFrame has a {type(self.df.index)} index.")
         # len for dask dataframe needs a client.
         if not self.use_dask and len(self.df) == 0:
             logger.error("Dataframe empty. Is the CSV file ok?")

--- a/aperturedb/cli/configure.py
+++ b/aperturedb/cli/configure.py
@@ -75,7 +75,8 @@ def get_configurations(file: str):
                 username=config["username"],
                 password=config["password"],
                 use_rest=config["use_rest"],
-                use_ssl=config["use_ssl"])
+                use_ssl=config["use_ssl"],
+                token=config["token"] if "token" in config else None)
             if "user_keys" in config:
                 configs[c].set_user_keys(config["user_keys"])
     active = configurations["active"]


### PR DESCRIPTION
CSVLoader actually wants an RangeIndex, since everything wants to use `start` and only RangeIndex has it. It's better to catch it earlier.

I missed passing token to Configuration when loading from the config file, so if you save a aperturedb key, it will lose the token when it loads.