### PR TITLE
update opencv, numpy

### DIFF
--- a/docker/dependencies/Dockerfile
+++ b/docker/dependencies/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 # Updated as per the newest release.
-ENV OPENCV_VERSION=4.7.0
+ENV OPENCV_VERSION=4.12.0
 
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -33,7 +33,7 @@ ENV PATH="/opt/node-${NODEJS_LTS}-linux-x64/bin:$PATH"
 # --     Libraries:                   /usr/lib/x86_64-linux-gnu/libpython3.10.so (ver 3.10.6)
 # --     numpy:                       /opt/venv/lib/python3.10/site-packages/numpy/core/include (ver 1.24.1)
 # --     install path:                lib/python3.10/site-packages/cv2/python-3.10
-RUN pip install "numpy<2"
+RUN pip install "numpy"
 
 RUN wget -q https://github.com/opencv/opencv/archive/$OPENCV_VERSION.tar.gz && \
     tar xf $OPENCV_VERSION.tar.gz && rm $OPENCV_VERSION.tar.gz && \


### PR DESCRIPTION
This had caused a downstream error in the workflows . 
A quick fix there was to pin open-python-headless.
Might need to revert that [change](https://github.com/aperture-data/workflows/pull/134).