### PR TITLE
fix: cleanup previous runner state properly to avoid permission denied errors in self-hosted runners

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Cleanup previous run
+      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs" || true
+      continue-on-error: true
+
     - uses: actions/checkout@v3
 
     - uses: actions/setup-python@v3

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -13,6 +13,10 @@ jobs:
 
     steps:
 
+    - name: Cleanup previous run
+      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs" || true
+      continue-on-error: true
+
     - uses: actions/checkout@v3
 
     - name: Login to DockerHub

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -13,6 +13,10 @@ jobs:
 
     steps:
 
+    - name: Cleanup previous run
+      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs" || true
+      continue-on-error: true
+
     - uses: actions/checkout@v3
 
     - name: Login to DockerHub
@@ -45,6 +49,10 @@ jobs:
     - benchmark
 
     steps:
+
+    - name: Cleanup previous run
+      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs" || true
+      continue-on-error: true
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ jobs:
 
     steps:
 
+    - name: Cleanup previous run
+      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs" || true
+      continue-on-error: true
+
     - uses: actions/checkout@v3
 
     - name: Login to DockerHub
@@ -45,6 +49,10 @@ jobs:
     - benchmark
 
     steps:
+
+    - name: Cleanup previous run
+      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs" || true
+      continue-on-error: true
 
     - uses: actions/checkout@v3
 
@@ -87,6 +95,10 @@ jobs:
     needs:
       - build_notebooks_and_publish_pypi
     steps:
+    - name: Cleanup previous run
+      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs" || true
+      continue-on-error: true
+
     - uses: actions/checkout@v3
     - name: repository dispatch
       run: |
@@ -103,6 +115,10 @@ jobs:
     needs:
       - build_notebooks_and_publish_pypi
     steps:
+    - name: Cleanup previous run
+      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs" || true
+      continue-on-error: true
+
     - uses: actions/checkout@v3
     - name: repository dispatch
       run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,6 +13,10 @@ jobs:
 
     steps:
 
+    - name: Cleanup previous run
+      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs" || true
+      continue-on-error: true
+
     - uses: actions/checkout@v3
 
     - name: Login to DockerHub

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,10 @@ jobs:
 
     steps:
 
+    - name: Cleanup previous run
+      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs" || true
+      continue-on-error: true
+
     - uses: actions/checkout@v3
 
     - name: Login to DockerHub
@@ -45,6 +49,10 @@ jobs:
     - deployer
 
     steps:
+
+    - name: Cleanup previous run
+      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs" || true
+      continue-on-error: true
 
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
Closes #N/A

This PR fixes the failing GitHub actions. The self-hosted runners are failing to run the `actions/checkout` step because the `test/aperturedb/logs` and `db*` folders created by previous docker runs are owned by root and cannot be removed by git clean. Adding a pre-checkout docker cleanup step solves this.