### PR TITLE
fix: remove redundant connection close in SSLError catch block (Closes #625)

### DIFF
--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -419,8 +419,6 @@ class Connector(object):
                         os.linesep
                 except ssl.SSLError as e:
                     logger.exception(f"Error wrapping socket.")
-                    self.conn.close()
-                    self.connected = False
                     raise
 
         except FileNotFoundError as e:

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -417,7 +417,7 @@ class Connector(object):
                         f"Refer to the documentation for more information: {SETUP_URL}" + os.linesep + \
                         f"Alternatively, SSL can be disabled by setting verify_hostname=False or use_ssl=False (not recommended)" + \
                         os.linesep
-                except ssl.SSLError as e:
+                except ssl.SSLError:
                     logger.exception(f"Error wrapping socket.")
                     raise
 


### PR DESCRIPTION
Closes #625. Removed the redundant connection close and assignment inside the `ssl.SSLError` catch block since the re-raised exception is natively caught and closed correctly by the `BaseException` block immediately underneath.