### PR TITLE
ci: fix permission denied on checkout by running chown

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Fix workspace permissions
+      run: sudo chown -R $USER:$USER ${{ github.workspace }} || true
+
     - uses: actions/checkout@v3
 
     - uses: actions/setup-python@v3

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -13,6 +13,9 @@ jobs:
 
     steps:
 
+    - name: Fix workspace permissions
+      run: sudo chown -R $USER:$USER ${{ github.workspace }} || true
+
     - uses: actions/checkout@v3
 
     - name: Login to DockerHub

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -13,6 +13,9 @@ jobs:
 
     steps:
 
+    - name: Fix workspace permissions
+      run: sudo chown -R $USER:$USER ${{ github.workspace }} || true
+
     - uses: actions/checkout@v3
 
     - name: Login to DockerHub
@@ -45,6 +48,9 @@ jobs:
     - benchmark
 
     steps:
+
+    - name: Fix workspace permissions
+      run: sudo chown -R $USER:$USER ${{ github.workspace }} || true
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ jobs:
 
     steps:
 
+    - name: Fix workspace permissions
+      run: sudo chown -R $USER:$USER ${{ github.workspace }} || true
+
     - uses: actions/checkout@v3
 
     - name: Login to DockerHub
@@ -45,6 +48,9 @@ jobs:
     - benchmark
 
     steps:
+
+    - name: Fix workspace permissions
+      run: sudo chown -R $USER:$USER ${{ github.workspace }} || true
 
     - uses: actions/checkout@v3
 
@@ -87,6 +93,9 @@ jobs:
     needs:
       - build_notebooks_and_publish_pypi
     steps:
+    - name: Fix workspace permissions
+      run: sudo chown -R $USER:$USER ${{ github.workspace }} || true
+
     - uses: actions/checkout@v3
     - name: repository dispatch
       run: |
@@ -103,6 +112,9 @@ jobs:
     needs:
       - build_notebooks_and_publish_pypi
     steps:
+    - name: Fix workspace permissions
+      run: sudo chown -R $USER:$USER ${{ github.workspace }} || true
+
     - uses: actions/checkout@v3
     - name: repository dispatch
       run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,6 +17,9 @@ jobs:
       run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db*"
       continue-on-error: true
 
+    - name: Fix workspace permissions
+      run: sudo chown -R $USER:$USER ${{ github.workspace }} || true
+
     - uses: actions/checkout@v3
 
     - name: Login to DockerHub

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,9 @@ jobs:
       run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs"
       continue-on-error: true
 
+    - name: Fix workspace permissions
+      run: sudo chown -R $USER:$USER ${{ github.workspace }} || true
+
     - uses: actions/checkout@v3
 
     - name: Login to DockerHub
@@ -53,6 +56,9 @@ jobs:
     - name: Cleanup previous run
       run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs"
       continue-on-error: true
+
+    - name: Fix workspace permissions
+      run: sudo chown -R $USER:$USER ${{ github.workspace }} || true
 
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
This PR fixes a CI issue where `actions/checkout@v3` fails with `EACCES: permission denied` when attempting to delete previous job artifacts (like root-owned `test/aperturedb/db_*` and `test/output` directories created by Docker during testing). 

By adding a `sudo chown -R $USER:$USER ${{ github.workspace }} || true` step *before* checkout, we ensure the runner has permissions to correctly clean the directory.