### PR TITLE
ci: use amazon/aws-cli docker image to avoid host dependency

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -186,9 +186,9 @@ push_aws_ecr(){
     PREFIX="aperturedata/"
     docker tag ${SRC_IMAGE} \
         684446431133.dkr.ecr.${REGION}.amazonaws.com/${DST_IMAGE}
-    aws ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin 684446431133.dkr.ecr.${REGION}.amazonaws.com
+    docker run --rm -e AWS_ACCESS_KEY_ID -e AWS_DEFAULT_REGION -e AWS_SECRET_ACCESS_KEY amazon/aws-cli ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin 684446431133.dkr.ecr.${REGION}.amazonaws.com
 
-    aws ecr create-repository --repository-name ${ECR_REPO_NAME} --region us-west-2  || true
+    docker run --rm -e AWS_ACCESS_KEY_ID -e AWS_DEFAULT_REGION -e AWS_SECRET_ACCESS_KEY amazon/aws-cli ecr create-repository --repository-name ${ECR_REPO_NAME} --region us-west-2  || true
 
     docker push 684446431133.dkr.ecr.${REGION}.amazonaws.com/${DST_IMAGE}
 }

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -43,7 +43,7 @@ if [[ $RESULT != 0 ]]; then
 		ARCHIVE_NAME=logs.tar.gz
 		DESTINATION="s3://${BUCKET}/aperturedb-${NOW}-${FILTER// /_}.tgz"
 		tar czf ${ARCHIVE_NAME} ${APERTUREDB_LOG_PATH}/..
-		aws s3 cp ${ARCHIVE_NAME} $DESTINATION
+		docker run --rm -v $(pwd):/workspace -w /workspace -e AWS_ACCESS_KEY_ID -e AWS_DEFAULT_REGION -e AWS_SECRET_ACCESS_KEY amazon/aws-cli s3 cp ${ARCHIVE_NAME} $DESTINATION
 		echo "Log output to $DESTINATION"
 	else
 		echo "Unable to output log, APERTUREDB_LOG_PATH not set."


### PR DESCRIPTION
This fixes a CI failure on the benchmark runners where the `aws` CLI binary is not installed, by running it through the official `amazon/aws-cli` container in `ci.sh`.