### PR TITLE
ci: split HTTP and non-HTTP tests into GitHub Actions matrix to reduce CI duration (Closes #659)

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   build-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        protocol: [http, non_http]
 
     runs-on:
     - benchmark
@@ -30,6 +34,7 @@ jobs:
 
     - name: Build and Run Tests
       env:
+        TEST_PROTOCOL: ${{ matrix.protocol }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -66,4 +71,3 @@ jobs:
         LENZ_TAG: dev
       run: BUILD_COMPLETE=true ./ci.sh
       shell: bash
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   build_and_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        protocol: [http, non_http]
 
     runs-on:
     - benchmark
@@ -30,6 +34,7 @@ jobs:
 
     - name: Build and Run Tests
       env:
+        TEST_PROTOCOL: ${{ matrix.protocol }}
         AWS_ACCESS_KEY_ID:     ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_DEFAULT_REGION:    ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   run_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        protocol: [http, non_http]
 
     runs-on:
     - gcp
@@ -34,11 +38,12 @@ jobs:
 
     - name: Build and Run Tests
       env:
+        TEST_PROTOCOL: ${{ matrix.protocol }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
-        RUNNER_NAME: ${{ runner.name }}
+        RUNNER_NAME: ${{ runner.name }}_${{ matrix.protocol }}
         RUN_TESTS: true
         NO_PUSH: true
         BRANCH_NAME: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   build-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        protocol: [http, non_http]
 
     runs-on:
     - self-hosted
@@ -35,10 +39,12 @@ jobs:
 
     - name: Build and Run Tests
       env:
+        TEST_PROTOCOL: ${{ matrix.protocol }}
         AWS_ACCESS_KEY_ID:     ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_DEFAULT_REGION:    ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+        RUNNER_NAME: ${{ runner.name }}_${{ matrix.protocol }}
       run: RUN_TESTS=true NO_PUSH=true UPDATE_BRANCH=true ./ci.sh
       shell: bash
 

--- a/test/run_test_container.sh
+++ b/test/run_test_container.sh
@@ -30,8 +30,16 @@ function run_aperturedb_instance(){
 
 IP_REGEX='[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}'
 
-GATEWAY_HTTP=$(run_aperturedb_instance "${RUNNER_NAME}_http" | grep $IP_REGEX )
-GATEWAY_NON_HTTP=$(run_aperturedb_instance "${RUNNER_NAME}_non_http" | grep $IP_REGEX )
+# Check if TEST_PROTOCOL is set, otherwise default to both
+TEST_PROTOCOL=${TEST_PROTOCOL:-"both"}
+
+if [ "$TEST_PROTOCOL" == "http" ] || [ "$TEST_PROTOCOL" == "both" ]; then
+    GATEWAY_HTTP=$(run_aperturedb_instance "${RUNNER_NAME}_http" | grep $IP_REGEX )
+fi
+
+if [ "$TEST_PROTOCOL" == "non_http" ] || [ "$TEST_PROTOCOL" == "both" ]; then
+    GATEWAY_NON_HTTP=$(run_aperturedb_instance "${RUNNER_NAME}_non_http" | grep $IP_REGEX )
+fi
 
 # The LOG_PATH and RUNNER_INFO_PATH are set to the current working directory
 LOG_PATH="$(pwd)/aperturedb/logs"
@@ -48,42 +56,57 @@ fi
 
 sleep 20 # wait for the containers to be up and running
 
-echo "running tests on docker image $REPOSITORY with $GATEWAY_HTTP and $GATEWAY_NON_HTTP"
-docker run \
-    -v $(pwd)/output:/aperturedata/test/output \
-    -v $(pwd)/${RUNNER_NAME}_http_ca:/ca \
-    --network=${RUNNER_NAME}_http_default \
-    -v "$LOG_PATH":"${TESTING_LOG_PATH}" \
-    -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-    -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION \
-    -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-    -e GCP_SERVICE_ACCOUNT_KEY="$GCP_SERVICE_ACCOUNT_KEY" \
-    -e APERTUREDB_LOG_PATH="${TESTING_LOG_PATH}" \
-    -e GATEWAY="nginx" \
-    -e FILTER="http" \
-    $REPOSITORY &
+pid1=0
+pid2=0
 
-pid1=$!
-docker run \
-    -v $(pwd)/output:/aperturedata/test/output \
-    -v $(pwd)/${RUNNER_NAME}_non_http_ca:/ca \
-    --network=${RUNNER_NAME}_non_http_default \
-    -v "$LOG_PATH":"${TESTING_LOG_PATH}" \
-    -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-    -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION \
-    -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-    -e GCP_SERVICE_ACCOUNT_KEY="$GCP_SERVICE_ACCOUNT_KEY" \
-    -e APERTUREDB_LOG_PATH="${TESTING_LOG_PATH}" \
-    -e GATEWAY="lenz" \
-    -e FILTER="not http" \
-    $REPOSITORY &
+if [ "$TEST_PROTOCOL" == "http" ] || [ "$TEST_PROTOCOL" == "both" ]; then
+    echo "running tests on docker image $REPOSITORY with $GATEWAY_HTTP"
+    docker run \
+        -v $(pwd)/output:/aperturedata/test/output \
+        -v $(pwd)/${RUNNER_NAME}_http_ca:/ca \
+        --network=${RUNNER_NAME}_http_default \
+        -v "$LOG_PATH":"${TESTING_LOG_PATH}" \
+        -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+        -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION \
+        -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+        -e GCP_SERVICE_ACCOUNT_KEY="$GCP_SERVICE_ACCOUNT_KEY" \
+        -e APERTUREDB_LOG_PATH="${TESTING_LOG_PATH}" \
+        -e GATEWAY="nginx" \
+        -e FILTER="http" \
+        $REPOSITORY &
+    pid1=$!
+fi
 
-pid2=$!
+if [ "$TEST_PROTOCOL" == "non_http" ] || [ "$TEST_PROTOCOL" == "both" ]; then
+    echo "running tests on docker image $REPOSITORY with $GATEWAY_NON_HTTP"
+    docker run \
+        -v $(pwd)/output:/aperturedata/test/output \
+        -v $(pwd)/${RUNNER_NAME}_non_http_ca:/ca \
+        --network=${RUNNER_NAME}_non_http_default \
+        -v "$LOG_PATH":"${TESTING_LOG_PATH}" \
+        -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+        -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION \
+        -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+        -e GCP_SERVICE_ACCOUNT_KEY="$GCP_SERVICE_ACCOUNT_KEY" \
+        -e APERTUREDB_LOG_PATH="${TESTING_LOG_PATH}" \
+        -e GATEWAY="lenz" \
+        -e FILTER="not http" \
+        $REPOSITORY &
+    pid2=$!
+fi
 
-wait $pid1
-exit_code1=$?
-wait $pid2
-exit_code2=$?
+exit_code1=0
+exit_code2=0
+
+if [ "$pid1" != "0" ]; then
+    wait $pid1
+    exit_code1=$?
+fi
+
+if [ "$pid2" != "0" ]; then
+    wait $pid2
+    exit_code2=$?
+fi
 
 if [ $exit_code1 -ne 0 ]; then
     echo "Tests failed for HTTP"
@@ -93,7 +116,6 @@ if [ $exit_code2 -ne 0 ]; then
     echo "Tests failed for NON_HTTP"
     exit $exit_code2
 fi
-
 
 echo "Tests completed"
 echo " --- Runner name: ${RUNNER_NAME} ---"


### PR DESCRIPTION
Implements Alternative 2 proposed in #659 to cut down CI time by avoiding CPU and I/O contention within the runner.

- Modifies `test/run_test_container.sh` to selectively execute either HTTP or TCP logic based on the `TEST_PROTOCOL` environment variable.
- Reconfigures `.github/workflows/pr.yaml`, `develop.yml`, `main.yml`, and `release.yaml` to utilize a `protocol: [http, non_http]` matrix strategy.
- The default behavior if `TEST_PROTOCOL` is omitted defaults backward compatibly to `both`.

Closes #659 