### PR TITLE
fix(utils): censor token information in error logs

### DIFF
--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -66,7 +66,27 @@ class Utils(object):
             rc, r, b = execute_query(self.client,
                                      query, blobs, success_statuses=success_statuses)
         except BaseException as e:
-            logger.error(self.client.get_last_response_str())
+            last_response = self.client.get_last_response_str()
+            # To prevent leaking sensitive token information, filter out token data
+            try:
+                import json
+                parsed_response = json.loads(last_response)
+                
+                # Censor authenticate response if present
+                if isinstance(parsed_response, list):
+                    for item in parsed_response:
+                        if "Authenticate" in item:
+                            auth_resp = item["Authenticate"]
+                            for key in ["refresh_token", "session_token"]:
+                                if key in auth_resp:
+                                    auth_resp[key] = "***CENSORED***"
+                            
+                last_response = json.dumps(parsed_response, indent=4, sort_keys=False)
+            except Exception:
+                # If we fail to parse, just log a censored generic message
+                last_response = "***CENSORED***"
+                
+            logger.error(last_response)
             raise e
 
         if rc != 0:
@@ -119,7 +139,27 @@ class Utils(object):
         try:
             schema = res[0]["GetSchema"]
         except BaseException as e:
-            logger.error(self.client.get_last_response_str())
+            last_response = self.client.get_last_response_str()
+            # To prevent leaking sensitive token information, filter out token data
+            try:
+                import json
+                parsed_response = json.loads(last_response)
+                
+                # Censor authenticate response if present
+                if isinstance(parsed_response, list):
+                    for item in parsed_response:
+                        if "Authenticate" in item:
+                            auth_resp = item["Authenticate"]
+                            for key in ["refresh_token", "session_token"]:
+                                if key in auth_resp:
+                                    auth_resp[key] = "***CENSORED***"
+                            
+                last_response = json.dumps(parsed_response, indent=4, sort_keys=False)
+            except Exception:
+                # If we fail to parse, just log a censored generic message
+                last_response = "***CENSORED***"
+                
+            logger.error(last_response)
             raise e
 
         return schema

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -210,6 +210,7 @@ class Utils(object):
                       'shape': 'none'}, graph_attr={'rankdir': 'LR'}, edge_attr={'color': colors['edge']})
 
         # autopep8: off
+        # autopep8: off
         # Add entities as nodes and connections as edges
         entities = r['entities']['classes']
         connections = r['connections']['classes']
@@ -264,7 +265,6 @@ class Utils(object):
 
             table += '</TABLE>>'
             dot.node(entity, label=table)
-        # autopep8: on
 
         if isinstance(connections, dict):
             for connection, data in connections.items():
@@ -273,6 +273,7 @@ class Utils(object):
                     dot.edge(f'{data["src"]}:{connection}',
                              f'{data["dst"]}')
 
+        # autopep8: on
         # Render the diagram inline
         s = Source(dot.source, filename="schema_diagram.gv", format="png")
 

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -71,7 +71,7 @@ class Utils(object):
             try:
                 import json
                 parsed_response = json.loads(last_response)
-                
+
                 # Censor authenticate response if present
                 if isinstance(parsed_response, list):
                     for item in parsed_response:
@@ -80,12 +80,13 @@ class Utils(object):
                             for key in ["refresh_token", "session_token"]:
                                 if key in auth_resp:
                                     auth_resp[key] = "***CENSORED***"
-                            
-                last_response = json.dumps(parsed_response, indent=4, sort_keys=False)
+
+                last_response = json.dumps(
+                    parsed_response, indent=4, sort_keys=False)
             except Exception:
                 # If we fail to parse, just log a censored generic message
                 last_response = "***CENSORED***"
-                
+
             logger.error(last_response)
             raise e
 
@@ -144,7 +145,7 @@ class Utils(object):
             try:
                 import json
                 parsed_response = json.loads(last_response)
-                
+
                 # Censor authenticate response if present
                 if isinstance(parsed_response, list):
                     for item in parsed_response:
@@ -153,12 +154,13 @@ class Utils(object):
                             for key in ["refresh_token", "session_token"]:
                                 if key in auth_resp:
                                     auth_resp[key] = "***CENSORED***"
-                            
-                last_response = json.dumps(parsed_response, indent=4, sort_keys=False)
+
+                last_response = json.dumps(
+                    parsed_response, indent=4, sort_keys=False)
             except Exception:
                 # If we fail to parse, just log a censored generic message
                 last_response = "***CENSORED***"
-                
+
             logger.error(last_response)
             raise e
 

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -209,11 +209,11 @@ class Utils(object):
         dot = Digraph(comment='ApertureDB Schema Diagram', node_attr={
                       'shape': 'none'}, graph_attr={'rankdir': 'LR'}, edge_attr={'color': colors['edge']})
 
+        # autopep8: off
         # Add entities as nodes and connections as edges
         entities = r['entities']['classes']
         connections = r['connections']['classes']
 
-        # autopep8: off
         for entity, data in entities.items():
             matched = data["matched"]
             # dictionary from name to (matched, indexed, type)

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -213,6 +213,7 @@ class Utils(object):
         entities = r['entities']['classes']
         connections = r['connections']['classes']
 
+        # autopep8: off
         for entity, data in entities.items():
             matched = data["matched"]
             # dictionary from name to (matched, indexed, type)
@@ -263,6 +264,7 @@ class Utils(object):
 
             table += '</TABLE>>'
             dot.node(entity, label=table)
+        # autopep8: on
 
         if isinstance(connections, dict):
             for connection, data in connections.items():

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -214,6 +214,7 @@ class Utils(object):
         # Add entities as nodes and connections as edges
         entities = r['entities']['classes']
         connections = r['connections']['classes']
+        # autopep8: off
 
         for entity, data in entities.items():
             matched = data["matched"]

--- a/fix_censor_tokens.patch
+++ b/fix_censor_tokens.patch
@@ -1,0 +1,112 @@
+--- aperturedb/Utils.py
++++ aperturedb/Utils.py
+@@ -28,6 +28,18 @@
+ DESCRIPTOR_CONNECTION_CLASS = "_DescriptorSetToDescriptor"
+ DEFAULT_METADATA_BATCH_SIZE = 100_000
+ 
++def censor_tokens(response):
++    import copy
++    if isinstance(response, list):
++        censored = copy.deepcopy(response)
++        for item in censored:
++            if isinstance(item, dict) and "Authenticate" in item:
++                auth = item["Authenticate"]
++                for k in ["refresh_token", "session_token"]:
++                    if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
++                        auth[k] = auth[k][:4] + "..." + auth[k][-4:]
++        return censored
++    return response
+ 
+ class Utils(object):
+     """
+@@ -62,17 +74,9 @@
+             rc, r, b = execute_query(self.client,
+                                      query, blobs, success_statuses=success_statuses)
+         except BaseException as e:
+-            import json
+             try:
+                 response_obj = json.loads(self.client.get_last_response_str())
+-                if isinstance(response_obj, list):
+-                    for item in response_obj:
+-                        if isinstance(item, dict) and "Authenticate" in item:
+-                            auth = item["Authenticate"]
+-                            for k in ["refresh_token", "session_token"]:
+-                                if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
+-                                    auth[k] = auth[k][:4] + \
+-                                        "..." + auth[k][-4:]
+-                logger.error(json.dumps(response_obj, indent=4))
++                logger.error(json.dumps(censor_tokens(response_obj), indent=4))
+             except:
+                 logger.error(self.client.get_last_response_str())
+             raise e
+@@ -131,17 +135,9 @@
+         try:
+             schema = res[0]["GetSchema"]
+         except BaseException as e:
+-            import json
+             try:
+                 response_obj = json.loads(self.client.get_last_response_str())
+-                if isinstance(response_obj, list):
+-                    for item in response_obj:
+-                        if isinstance(item, dict) and "Authenticate" in item:
+-                            auth = item["Authenticate"]
+-                            for k in ["refresh_token", "session_token"]:
+-                                if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
+-                                    auth[k] = auth[k][:4] + \
+-                                        "..." + auth[k][-4:]
+-                logger.error(json.dumps(response_obj, indent=4))
++                logger.error(json.dumps(censor_tokens(response_obj), indent=4))
+             except:
+                 logger.error(self.client.get_last_response_str())
+             raise e
+--- aperturedb/CommonLibrary.py
++++ aperturedb/CommonLibrary.py
+@@ -298,20 +298,8 @@
+     result = 0
+     logger.debug(f"Query={query}")
+     r, b = client.query(query, blobs)
+ 
+-    # Censor token information in the response for logging
+-    def censor_tokens(response):
+-        import copy
+-        if isinstance(response, list):
+-            censored = copy.deepcopy(response)
+-            for item in censored:
+-                if isinstance(item, dict) and "Authenticate" in item:
+-                    auth = item["Authenticate"]
+-                    for k in ["refresh_token", "session_token"]:
+-                        if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
+-                            auth[k] = auth[k][:4] + "..." + auth[k][-4:]
+-            return censored
+-        return response
+-
++    from aperturedb.Utils import censor_tokens
+     censored_r = censor_tokens(r)
+     logger.debug(f"Response={censored_r}")
+ 
+--- aperturedb/Connector.py
++++ aperturedb/Connector.py
+@@ -598,23 +598,8 @@
+                             exc_info=True, stack_info=True)
+ 
+-            # Censor token information in the response for logging
+-            def censor_tokens(response):
+-                import copy
+-                if isinstance(response, list):
+-                    censored = copy.deepcopy(response)
+-                    for item in censored:
+-                        if isinstance(item, dict) and "Authenticate" in item:
+-                            auth = item["Authenticate"]
+-                            for k in ["refresh_token", "session_token"]:
+-                                if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
+-                                    auth[k] = auth[k][:4] + \
+-                                        "..." + auth[k][-4:]
+-                    return censored
+-                return response
+-
++            from aperturedb.Utils import censor_tokens
+             if hasattr(self, 'last_response') and self.last_response:
+                 censored_response = censor_tokens(self.last_response)
+                 logger.error(censored_response)
+ 
+             raise


### PR DESCRIPTION
Closes #545

When a query fails inside `Utils.execute()`, the full JSON response was being dumped to the error log via `get_last_response_str()`. In some cases, this response would include active session tokens and refresh tokens from earlier in the batch.

This PR parses the JSON response right before it is logged and replaces any tokens with `***CENSORED***`.