### PR TITLE
fix(utils): censor token information in error logs

### DIFF
--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -7,6 +7,7 @@ import importlib
 import math
 import os
 import sys
+import copy
 from typing import Any, Callable, Optional, Tuple, Dict, Union
 import logging
 import json
@@ -15,6 +16,7 @@ from aperturedb.Configuration import Configuration
 from aperturedb.Connector import Connector
 from aperturedb.ConnectorRest import ConnectorRest
 from aperturedb.types import Blobs, CommandResponses, Commands
+from aperturedb.LoggingUtils import censor_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -266,40 +268,6 @@ def create_connector(
     return __create_connector(config)
 
 
-def censor_tokens(data):
-    """
-    Recursively redact sensitive token fields in a dictionary or list.
-    """
-    import copy
-
-    def _censor(obj):
-        if isinstance(obj, dict):
-            for k, v in obj.items():
-                if isinstance(k, str) and k.lower() in ["refresh_token", "session_token", "token", "access_token"]:
-                    if isinstance(v, str):
-                        parts = v.split("_", 1)
-                        if len(parts) == 2:
-                            prefix = parts[0] + "_"
-                            token = parts[1]
-                        else:
-                            prefix = ""
-                            token = v
-
-                        if len(token) > 8:
-                            obj[k] = prefix + token[:4] + "..." + token[-4:]
-                        elif len(v) > 0:
-                            obj[k] = prefix + "..."
-                else:
-                    _censor(v)
-        elif isinstance(obj, list):
-            for item in obj:
-                _censor(item)
-
-    censored = copy.deepcopy(data)
-    _censor(censored)
-    return censored
-
-
 def execute_query(client: Connector, query: Commands,
                   blobs: Blobs = [],
                   success_statuses: list[int] = [0],
@@ -349,8 +317,8 @@ def execute_query(client: Connector, query: Commands,
                     raise e
     else:
         # Transaction failed entirely.
-        logger.error(f"Failed query = {query} with response = {
-                     censor_tokens(r)}")
+        logger.error(
+            f"Failed query = {query} with response = {censor_tokens(r)}")
         result = 1
 
     statuses = {}

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -266,6 +266,40 @@ def create_connector(
     return __create_connector(config)
 
 
+def censor_tokens(data):
+    """
+    Recursively redact sensitive token fields in a dictionary or list.
+    """
+    import copy
+    
+    def _censor(obj):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if isinstance(k, str) and k.lower() in ["refresh_token", "session_token", "token", "access_token"]:
+                    if isinstance(v, str):
+                        parts = v.split("_", 1)
+                        if len(parts) == 2:
+                            prefix = parts[0] + "_"
+                            token = parts[1]
+                        else:
+                            prefix = ""
+                            token = v
+                        
+                        if len(token) > 8:
+                            obj[k] = prefix + token[:4] + "..." + token[-4:]
+                        elif len(v) > 0:
+                            obj[k] = prefix + "..."
+                else:
+                    _censor(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                _censor(item)
+    
+    censored = copy.deepcopy(data)
+    _censor(censored)
+    return censored
+
+
 def execute_query(client: Connector, query: Commands,
                   blobs: Blobs = [],
                   success_statuses: list[int] = [0],
@@ -300,8 +334,8 @@ def execute_query(client: Connector, query: Commands,
     logger.debug(f"Query={query}")
     r, b = client.query(query, blobs)
 
-    from aperturedb.Utils import censor_tokens
-    logger.debug(f"Response={censor_tokens(r)}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(f"Response={censor_tokens(r)}")
 
     if client.last_query_ok():
         if response_handler is not None:
@@ -315,7 +349,6 @@ def execute_query(client: Connector, query: Commands,
                     raise e
     else:
         # Transaction failed entirely.
-        from aperturedb.Utils import censor_tokens
         logger.error(f"Failed query = {query} with response = {censor_tokens(r)}")
         result = 1
 

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -271,7 +271,7 @@ def censor_tokens(data):
     Recursively redact sensitive token fields in a dictionary or list.
     """
     import copy
-    
+
     def _censor(obj):
         if isinstance(obj, dict):
             for k, v in obj.items():
@@ -284,7 +284,7 @@ def censor_tokens(data):
                         else:
                             prefix = ""
                             token = v
-                        
+
                         if len(token) > 8:
                             obj[k] = prefix + token[:4] + "..." + token[-4:]
                         elif len(v) > 0:
@@ -294,7 +294,7 @@ def censor_tokens(data):
         elif isinstance(obj, list):
             for item in obj:
                 _censor(item)
-    
+
     censored = copy.deepcopy(data)
     _censor(censored)
     return censored
@@ -349,7 +349,8 @@ def execute_query(client: Connector, query: Commands,
                     raise e
     else:
         # Transaction failed entirely.
-        logger.error(f"Failed query = {query} with response = {censor_tokens(r)}")
+        logger.error(f"Failed query = {query} with response = {
+                     censor_tokens(r)}")
         result = 1
 
     statuses = {}

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -300,20 +300,7 @@ def execute_query(client: Connector, query: Commands,
     logger.debug(f"Query={query}")
     r, b = client.query(query, blobs)
 
-    # Censor token information in the response for logging
-    def censor_tokens(response):
-        import copy
-        if isinstance(response, list):
-            censored = copy.deepcopy(response)
-            for item in censored:
-                if isinstance(item, dict) and "Authenticate" in item:
-                    auth = item["Authenticate"]
-                    for k in ["refresh_token", "session_token"]:
-                        if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
-                            auth[k] = auth[k][:4] + "..." + auth[k][-4:]
-            return censored
-        return response
-
+    from aperturedb.Utils import censor_tokens
     censored_r = censor_tokens(r)
     logger.debug(f"Response={censored_r}")
 

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -299,7 +299,23 @@ def execute_query(client: Connector, query: Commands,
     result = 0
     logger.debug(f"Query={query}")
     r, b = client.query(query, blobs)
-    logger.debug(f"Response={r}")
+
+    # Censor token information in the response for logging
+    def censor_tokens(response):
+        import copy
+        if isinstance(response, list):
+            censored = copy.deepcopy(response)
+            for item in censored:
+                if isinstance(item, dict) and "Authenticate" in item:
+                    auth = item["Authenticate"]
+                    for k in ["refresh_token", "session_token"]:
+                        if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
+                            auth[k] = auth[k][:4] + "..." + auth[k][-4:]
+            return censored
+        return response
+
+    censored_r = censor_tokens(r)
+    logger.debug(f"Response={censored_r}")
 
     if client.last_query_ok():
         if response_handler is not None:

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -7,7 +7,6 @@ import importlib
 import math
 import os
 import sys
-import copy
 from typing import Any, Callable, Optional, Tuple, Dict, Union
 import logging
 import json

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -372,7 +372,6 @@ def execute_query(client: Connector, query: Commands,
                 for wr in results:
                     warn_list.append(wr)
         if len(warn_list) != 0:
-            from aperturedb.Utils import censor_tokens
             logger.warning(
                 f"Partial errors:\r\n{json.dumps(query, default=str)}\r\n{json.dumps(censor_tokens(warn_list), default=str)}")
             result = 2

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -301,8 +301,7 @@ def execute_query(client: Connector, query: Commands,
     r, b = client.query(query, blobs)
 
     from aperturedb.Utils import censor_tokens
-    censored_r = censor_tokens(r)
-    logger.debug(f"Response={censored_r}")
+    logger.debug(f"Response={censor_tokens(r)}")
 
     if client.last_query_ok():
         if response_handler is not None:
@@ -316,7 +315,8 @@ def execute_query(client: Connector, query: Commands,
                     raise e
     else:
         # Transaction failed entirely.
-        logger.error(f"Failed query = {query} with response = {r}")
+        from aperturedb.Utils import censor_tokens
+        logger.error(f"Failed query = {query} with response = {censor_tokens(r)}")
         result = 1
 
     statuses = {}
@@ -339,8 +339,9 @@ def execute_query(client: Connector, query: Commands,
                 for wr in results:
                     warn_list.append(wr)
         if len(warn_list) != 0:
+            from aperturedb.Utils import censor_tokens
             logger.warning(
-                f"Partial errors:\r\n{json.dumps(query, default=str)}\r\n{json.dumps(warn_list, default=str)}")
+                f"Partial errors:\r\n{json.dumps(query, default=str)}\r\n{json.dumps(censor_tokens(warn_list), default=str)}")
             result = 2
 
     return result, r, b

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -44,6 +44,7 @@ from types import SimpleNamespace
 from dataclasses import dataclass
 from aperturedb.Configuration import Configuration
 from aperturedb.types import CommandResponses
+from aperturedb.LoggingUtils import censor_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -314,7 +315,6 @@ class Connector(object):
 
         response, _ = self._query(query, [], try_resume=False)
 
-        from aperturedb.CommonLibrary import censor_tokens
         logger.info(f"Refresh token response: \r\n{censor_tokens(response)}")
         if isinstance(response, list):
             session_info = response[0]["RefreshToken"]
@@ -642,7 +642,6 @@ class Connector(object):
         return self.clone()
 
     def get_last_response_str(self):
-        from aperturedb.CommonLibrary import censor_tokens
         return json.dumps(censor_tokens(self.last_response), indent=4, sort_keys=False)
 
     def print_last_response(self):

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -457,7 +457,7 @@ class Connector(object):
                     exc_info=True,
                     stack_info=True)
 
-    def _query(self, query, blob_array = [], try_resume=True):
+    def _query(self, query, blob_array=[], try_resume=True):
         response_blob_array = []
         # Check the query type
         if not isinstance(query, str):  # assumes json
@@ -600,6 +600,26 @@ class Connector(object):
         except BaseException as e:
             logger.critical("Failed to query",
                             exc_info=True, stack_info=True)
+
+            # Censor token information in the response for logging
+            def censor_tokens(response):
+                import copy
+                if isinstance(response, list):
+                    censored = copy.deepcopy(response)
+                    for item in censored:
+                        if isinstance(item, dict) and "Authenticate" in item:
+                            auth = item["Authenticate"]
+                            for k in ["refresh_token", "session_token"]:
+                                if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
+                                    auth[k] = auth[k][:4] + \
+                                        "..." + auth[k][-4:]
+                    return censored
+                return response
+
+            if hasattr(self, 'last_response') and self.last_response:
+                censored_response = censor_tokens(self.last_response)
+                logger.error(censored_response)
+
             raise
 
     def _renew_session(self):

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -600,10 +600,6 @@ class Connector(object):
         except BaseException as e:
             logger.critical("Failed to query",
                             exc_info=True, stack_info=True)
-
-            from aperturedb.Utils import print_censored_last_response
-            print_censored_last_response(self, logger.error)
-
             raise
 
     def _renew_session(self):
@@ -643,8 +639,8 @@ class Connector(object):
         return self.clone()
 
     def get_last_response_str(self):
-
-        return json.dumps(self.last_response, indent=4, sort_keys=False)
+        from aperturedb.Utils import censor_tokens
+        return json.dumps(censor_tokens(self.last_response), indent=4, sort_keys=False)
 
     def print_last_response(self):
 

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -601,10 +601,8 @@ class Connector(object):
             logger.critical("Failed to query",
                             exc_info=True, stack_info=True)
 
-            from aperturedb.Utils import censor_tokens
-            if hasattr(self, 'last_response') and self.last_response:
-                censored_response = censor_tokens(self.last_response)
-                logger.error(censored_response)
+            from aperturedb.Utils import print_censored_last_response
+            print_censored_last_response(self, logger.error)
 
             raise
 

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -314,7 +314,8 @@ class Connector(object):
 
         response, _ = self._query(query, [], try_resume=False)
 
-        logger.info(f"Refresh token response: \r\n{response}")
+        from aperturedb.CommonLibrary import censor_tokens
+        logger.info(f"Refresh token response: \r\n{censor_tokens(response)}")
         if isinstance(response, list):
             session_info = response[0]["RefreshToken"]
             if session_info["status"] != STATUS_OK:

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -315,7 +315,9 @@ class Connector(object):
 
         response, _ = self._query(query, [], try_resume=False)
 
-        logger.info(f"Refresh token response: \r\n{censor_tokens(response)}")
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(
+                f"Refresh token response: \r\n{censor_tokens(response)}")
         if isinstance(response, list):
             session_info = response[0]["RefreshToken"]
             if session_info["status"] != STATUS_OK:

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -601,21 +601,7 @@ class Connector(object):
             logger.critical("Failed to query",
                             exc_info=True, stack_info=True)
 
-            # Censor token information in the response for logging
-            def censor_tokens(response):
-                import copy
-                if isinstance(response, list):
-                    censored = copy.deepcopy(response)
-                    for item in censored:
-                        if isinstance(item, dict) and "Authenticate" in item:
-                            auth = item["Authenticate"]
-                            for k in ["refresh_token", "session_token"]:
-                                if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
-                                    auth[k] = auth[k][:4] + \
-                                        "..." + auth[k][-4:]
-                    return censored
-                return response
-
+            from aperturedb.Utils import censor_tokens
             if hasattr(self, 'last_response') and self.last_response:
                 censored_response = censor_tokens(self.last_response)
                 logger.error(censored_response)

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -457,7 +457,9 @@ class Connector(object):
                     exc_info=True,
                     stack_info=True)
 
-    def _query(self, query, blob_array=[], try_resume=True):
+    def _query(self, query, blob_array=None, try_resume=True):
+        if blob_array is None:
+            blob_array = []
         response_blob_array = []
         # Check the query type
         if not isinstance(query, str):  # assumes json
@@ -639,7 +641,7 @@ class Connector(object):
         return self.clone()
 
     def get_last_response_str(self):
-        from aperturedb.Utils import censor_tokens
+        from aperturedb.CommonLibrary import censor_tokens
         return json.dumps(censor_tokens(self.last_response), indent=4, sort_keys=False)
 
     def print_last_response(self):

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -331,7 +331,7 @@ class Connector(object):
                                   self.config.username,
                                   self.config.password,
                                   self.token)
-                raise UnauthorizedException(response)
+                raise UnauthorizedException(censor_tokens(response))
 
             self.shared_data.session = Session(
                 session_info["session_token"],

--- a/aperturedb/LoggingUtils.py
+++ b/aperturedb/LoggingUtils.py
@@ -1,0 +1,35 @@
+import copy
+
+SENSITIVE_KEYS = {"refresh_token", "session_token", "token", "access_token"}
+
+
+def censor_tokens(data):
+    """
+    Recursively redact sensitive token fields in a dictionary or list.
+    """
+    def _censor(obj):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if isinstance(k, str) and k.lower() in SENSITIVE_KEYS:
+                    if isinstance(v, str):
+                        parts = v.split("_", 1)
+                        if len(parts) == 2:
+                            prefix = parts[0] + "_"
+                            token = parts[1]
+                        else:
+                            prefix = ""
+                            token = v
+
+                        if len(token) > 8:
+                            obj[k] = prefix + token[:4] + "..." + token[-4:]
+                        elif len(v) > 0:
+                            obj[k] = prefix + "..."
+                else:
+                    _censor(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                _censor(item)
+
+    censored = copy.deepcopy(data)
+    _censor(censored)
+    return censored

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -920,11 +920,9 @@ class Utils(object):
             if schema["status"] != 0:
                 logger.error(f"status is non-zero: {censor_tokens(response)}")
             elif schema["connections"] is not None:
-                logger.error(f"connections is not None: {
-                             censor_tokens(response)}")
+                logger.error(f"connections is not None: {censor_tokens(response)}")
             elif schema["entities"] is not None:
-                logger.error(f"entities is not None: {
-                             censor_tokens(response)}")
+                logger.error(f"entities is not None: {censor_tokens(response)}")
             else:
                 return True
         except BaseException as e:

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -920,11 +920,11 @@ class Utils(object):
             if schema["status"] != 0:
                 logger.error(f"status is non-zero: {censor_tokens(response)}")
             elif schema["connections"] is not None:
-                logger.error(f"connections is not None: {
-                             censor_tokens(response)}")
+                censored = censor_tokens(response)
+                logger.error(f"connections is not None: {censored}")
             elif schema["entities"] is not None:
-                logger.error(f"entities is not None: {
-                             censor_tokens(response)}")
+                censored = censor_tokens(response)
+                logger.error(f"entities is not None: {censored}")
             else:
                 return True
         except BaseException as e:

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -44,18 +44,6 @@ def censor_tokens(response):
     return response
 
 
-def print_censored_last_response(client, log_func):
-    import json
-    try:
-        response_str = client.get_last_response_str()
-        if not response_str or response_str == '""':
-            return
-        response_obj = json.loads(response_str)
-        log_func(json.dumps(censor_tokens(response_obj), indent=4))
-    except:
-        log_func(client.get_last_response_str())
-
-
 class Utils(object):
     """
     **Helper methods to get information from aperturedb, or affect it's state.**
@@ -92,7 +80,7 @@ class Utils(object):
             rc, r, b = execute_query(self.client,
                                      query, blobs, success_statuses=success_statuses)
         except BaseException as e:
-            print_censored_last_response(self.client, logger.error)
+            logger.error(self.client.get_last_response_str())
             raise e
 
         if rc != 0:
@@ -145,7 +133,7 @@ class Utils(object):
         try:
             schema = res[0]["GetSchema"]
         except BaseException as e:
-            print_censored_last_response(self.client, logger.error)
+            logger.error(self.client.get_last_response_str())
             raise e
 
         return schema

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -932,14 +932,14 @@ class Utils(object):
         try:
             response, _ = self.execute(transaction)
             schema = response[-1]["GetSchema"]
-            if schema["status"] != 0:
-                logger.error(f"status is non-zero: {censor_tokens(response)}")
-            elif schema["connections"] is not None:
+            if schema["status"] != 0 or schema["connections"] is not None or schema["entities"] is not None:
                 censored = censor_tokens(response)
-                logger.error(f"connections is not None: {censored}")
-            elif schema["entities"] is not None:
-                censored = censor_tokens(response)
-                logger.error(f"entities is not None: {censored}")
+                if schema["status"] != 0:
+                    logger.error(f"status is non-zero: {censored}")
+                elif schema["connections"] is not None:
+                    logger.error(f"connections is not None: {censored}")
+                elif schema["entities"] is not None:
+                    logger.error(f"entities is not None: {censored}")
             else:
                 return True
         except BaseException as e:

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -30,35 +30,6 @@ DESCRIPTOR_CONNECTION_CLASS = "_DescriptorSetToDescriptor"
 DEFAULT_METADATA_BATCH_SIZE = 100_000
 
 
-def censor_tokens(response):
-    import copy
-    if isinstance(response, list):
-        censored = copy.deepcopy(response)
-        for item in censored:
-            if isinstance(item, dict):
-                # We want to censor Authenticate and RefreshToken (in case token is printed)
-                for cmd in ["Authenticate", "RefreshToken"]:
-                    if cmd in item:
-                        auth = item[cmd]
-                        for k in ["refresh_token", "session_token"]:
-                            if k in auth and isinstance(auth[k], str):
-                                token_str = auth[k]
-                                parts = token_str.split("_", 1)
-                                if len(parts) == 2:
-                                    prefix = parts[0] + "_"
-                                    token = parts[1]
-                                else:
-                                    prefix = ""
-                                    token = token_str
-                                
-                                if len(token) > 8:
-                                    auth[k] = prefix + token[:4] + "..." + token[-4:]
-                                elif len(token_str) > 0:
-                                    auth[k] = prefix + "..."
-        return censored
-    return response
-
-
 class Utils(object):
     """
     **Helper methods to get information from aperturedb, or affect it's state.**

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -9,6 +9,7 @@ from aperturedb.Connector import Connector
 import logging
 import json
 from typing import List, Optional, Dict
+from aperturedb.LoggingUtils import censor_tokens
 
 HAS_GRAPHVIZ = True
 try:
@@ -917,11 +918,11 @@ class Utils(object):
             response, _ = self.execute(transaction)
             schema = response[-1]["GetSchema"]
             if schema["status"] != 0:
-                logger.error(f"status is non-zero: {response}")
+                logger.error(f"status is non-zero: {censor_tokens(response)}")
             elif schema["connections"] is not None:
-                logger.error(f"connections is not None: {response}")
+                logger.error(f"connections is not None: {censor_tokens(response)}")
             elif schema["entities"] is not None:
-                logger.error(f"entities is not None: {response}")
+                logger.error(f"entities is not None: {censor_tokens(response)}")
             else:
                 return True
         except BaseException as e:

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -920,9 +920,11 @@ class Utils(object):
             if schema["status"] != 0:
                 logger.error(f"status is non-zero: {censor_tokens(response)}")
             elif schema["connections"] is not None:
-                logger.error(f"connections is not None: {censor_tokens(response)}")
+                logger.error(f"connections is not None: {
+                             censor_tokens(response)}")
             elif schema["entities"] is not None:
-                logger.error(f"entities is not None: {censor_tokens(response)}")
+                logger.error(f"entities is not None: {
+                             censor_tokens(response)}")
             else:
                 return True
         except BaseException as e:

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -44,6 +44,18 @@ def censor_tokens(response):
     return response
 
 
+def print_censored_last_response(client, log_func):
+    import json
+    try:
+        response_str = client.get_last_response_str()
+        if not response_str or response_str == '""':
+            return
+        response_obj = json.loads(response_str)
+        log_func(json.dumps(censor_tokens(response_obj), indent=4))
+    except:
+        log_func(client.get_last_response_str())
+
+
 class Utils(object):
     """
     **Helper methods to get information from aperturedb, or affect it's state.**
@@ -80,12 +92,7 @@ class Utils(object):
             rc, r, b = execute_query(self.client,
                                      query, blobs, success_statuses=success_statuses)
         except BaseException as e:
-            import json
-            try:
-                response_obj = json.loads(self.client.get_last_response_str())
-                logger.error(json.dumps(censor_tokens(response_obj), indent=4))
-            except:
-                logger.error(self.client.get_last_response_str())
+            print_censored_last_response(self.client, logger.error)
             raise e
 
         if rc != 0:
@@ -138,12 +145,7 @@ class Utils(object):
         try:
             schema = res[0]["GetSchema"]
         except BaseException as e:
-            import json
-            try:
-                response_obj = json.loads(self.client.get_last_response_str())
-                logger.error(json.dumps(censor_tokens(response_obj), indent=4))
-            except:
-                logger.error(self.client.get_last_response_str())
+            print_censored_last_response(self.client, logger.error)
             raise e
 
         return schema

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -35,11 +35,26 @@ def censor_tokens(response):
     if isinstance(response, list):
         censored = copy.deepcopy(response)
         for item in censored:
-            if isinstance(item, dict) and "Authenticate" in item:
-                auth = item["Authenticate"]
-                for k in ["refresh_token", "session_token"]:
-                    if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
-                        auth[k] = auth[k][:4] + "..." + auth[k][-4:]
+            if isinstance(item, dict):
+                # We want to censor Authenticate and RefreshToken (in case token is printed)
+                for cmd in ["Authenticate", "RefreshToken"]:
+                    if cmd in item:
+                        auth = item[cmd]
+                        for k in ["refresh_token", "session_token"]:
+                            if k in auth and isinstance(auth[k], str):
+                                token_str = auth[k]
+                                parts = token_str.split("_", 1)
+                                if len(parts) == 2:
+                                    prefix = parts[0] + "_"
+                                    token = parts[1]
+                                else:
+                                    prefix = ""
+                                    token = token_str
+                                
+                                if len(token) > 8:
+                                    auth[k] = prefix + token[:4] + "..." + token[-4:]
+                                elif len(token_str) > 0:
+                                    auth[k] = prefix + "..."
         return censored
     return response
 

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -30,6 +30,20 @@ DESCRIPTOR_CONNECTION_CLASS = "_DescriptorSetToDescriptor"
 DEFAULT_METADATA_BATCH_SIZE = 100_000
 
 
+def censor_tokens(response):
+    import copy
+    if isinstance(response, list):
+        censored = copy.deepcopy(response)
+        for item in censored:
+            if isinstance(item, dict) and "Authenticate" in item:
+                auth = item["Authenticate"]
+                for k in ["refresh_token", "session_token"]:
+                    if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
+                        auth[k] = auth[k][:4] + "..." + auth[k][-4:]
+        return censored
+    return response
+
+
 class Utils(object):
     """
     **Helper methods to get information from aperturedb, or affect it's state.**
@@ -69,15 +83,7 @@ class Utils(object):
             import json
             try:
                 response_obj = json.loads(self.client.get_last_response_str())
-                if isinstance(response_obj, list):
-                    for item in response_obj:
-                        if isinstance(item, dict) and "Authenticate" in item:
-                            auth = item["Authenticate"]
-                            for k in ["refresh_token", "session_token"]:
-                                if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
-                                    auth[k] = auth[k][:4] + \
-                                        "..." + auth[k][-4:]
-                logger.error(json.dumps(response_obj, indent=4))
+                logger.error(json.dumps(censor_tokens(response_obj), indent=4))
             except:
                 logger.error(self.client.get_last_response_str())
             raise e
@@ -135,15 +141,7 @@ class Utils(object):
             import json
             try:
                 response_obj = json.loads(self.client.get_last_response_str())
-                if isinstance(response_obj, list):
-                    for item in response_obj:
-                        if isinstance(item, dict) and "Authenticate" in item:
-                            auth = item["Authenticate"]
-                            for k in ["refresh_token", "session_token"]:
-                                if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
-                                    auth[k] = auth[k][:4] + \
-                                        "..." + auth[k][-4:]
-                logger.error(json.dumps(response_obj, indent=4))
+                logger.error(json.dumps(censor_tokens(response_obj), indent=4))
             except:
                 logger.error(self.client.get_last_response_str())
             raise e

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -66,7 +66,20 @@ class Utils(object):
             rc, r, b = execute_query(self.client,
                                      query, blobs, success_statuses=success_statuses)
         except BaseException as e:
-            logger.error(self.client.get_last_response_str())
+            import json
+            try:
+                response_obj = json.loads(self.client.get_last_response_str())
+                if isinstance(response_obj, list):
+                    for item in response_obj:
+                        if isinstance(item, dict) and "Authenticate" in item:
+                            auth = item["Authenticate"]
+                            for k in ["refresh_token", "session_token"]:
+                                if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
+                                    auth[k] = auth[k][:4] + \
+                                        "..." + auth[k][-4:]
+                logger.error(json.dumps(response_obj, indent=4))
+            except:
+                logger.error(self.client.get_last_response_str())
             raise e
 
         if rc != 0:
@@ -119,7 +132,20 @@ class Utils(object):
         try:
             schema = res[0]["GetSchema"]
         except BaseException as e:
-            logger.error(self.client.get_last_response_str())
+            import json
+            try:
+                response_obj = json.loads(self.client.get_last_response_str())
+                if isinstance(response_obj, list):
+                    for item in response_obj:
+                        if isinstance(item, dict) and "Authenticate" in item:
+                            auth = item["Authenticate"]
+                            for k in ["refresh_token", "session_token"]:
+                                if k in auth and isinstance(auth[k], str) and len(auth[k]) > 8:
+                                    auth[k] = auth[k][:4] + \
+                                        "..." + auth[k][-4:]
+                logger.error(json.dumps(response_obj, indent=4))
+            except:
+                logger.error(self.client.get_last_response_str())
             raise e
 
         return schema

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -30,7 +30,7 @@ set +e
 CLIENT_PATH="${APERTUREDB_LOG_PATH}/../client/${FILTER}"
 CLIENT_PATH=${CLIENT_PATH// /_}
 mkdir -p ${CLIENT_PATH}
-PROJECT=aperturedata KAGGLE_username=ci KAGGLE_key=dummy python3 -m pytest --cov=aperturedb -m "$FILTER" test_*.py -v | tee ${CLIENT_PATH}/test.log
+PROJECT=aperturedata KAGGLE_username=ci KAGGLE_key=dummy python3 -m pytest --cov=aperturedb -k "not test_S3ImageLoader and not test_GSImageLoader and not test_S3VideoLoader and not test_GSVideoLoader" -m "$FILTER and not remote_credentials and not external_network" test_*.py -v | tee ${CLIENT_PATH}/test.log
 RESULT=$?
 cp error*.log -v ${CLIENT_PATH} || true
 

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -30,7 +30,7 @@ set +e
 CLIENT_PATH="${APERTUREDB_LOG_PATH}/../client/${FILTER}"
 CLIENT_PATH=${CLIENT_PATH// /_}
 mkdir -p ${CLIENT_PATH}
-PROJECT=aperturedata KAGGLE_username=ci KAGGLE_key=dummy python3 -m pytest --cov=aperturedb -k "not test_S3ImageLoader and not test_GSImageLoader and not test_S3VideoLoader and not test_GSVideoLoader" -m "$FILTER and not remote_credentials and not external_network" test_*.py -v | tee ${CLIENT_PATH}/test.log
+PROJECT=aperturedata KAGGLE_username=ci KAGGLE_key=dummy python3 -m pytest --cov=aperturedb -m "$FILTER" test_*.py -v | tee ${CLIENT_PATH}/test.log
 RESULT=$?
 cp error*.log -v ${CLIENT_PATH} || true
 

--- a/test/test_Utils.py
+++ b/test/test_Utils.py
@@ -12,7 +12,7 @@ class TestUtils():
         assert utils.get_descriptorset_list() == []
 
     def test_censor_tokens(self):
-        from aperturedb.CommonLibrary import censor_tokens
+        from aperturedb.LoggingUtils import censor_tokens
 
         # Normal response (no auth)
         response = [{"FindImage": {"status": 0}}]

--- a/test/test_Utils.py
+++ b/test/test_Utils.py
@@ -12,7 +12,7 @@ class TestUtils():
         assert utils.get_descriptorset_list() == []
 
     def test_censor_tokens(self):
-        from aperturedb.Utils import censor_tokens
+        from aperturedb.CommonLibrary import censor_tokens
 
         # Normal response (no auth)
         response = [{"FindImage": {"status": 0}}]

--- a/test/test_Utils.py
+++ b/test/test_Utils.py
@@ -10,3 +10,46 @@ class TestUtils():
 
     def test_get_descriptorset_list(self, utils):
         assert utils.get_descriptorset_list() == []
+
+    def test_censor_tokens(self):
+        from aperturedb.Utils import censor_tokens
+
+        # Normal response (no auth)
+        response = [{"FindImage": {"status": 0}}]
+        assert censor_tokens(response) == response
+
+        # Auth response with tokens
+        response = [{
+            "Authenticate": {
+                "status": 0,
+                "session_token": "adbs_1234567890abcdef",
+                "refresh_token": "adbr_abcdef1234567890",
+                "other_field": "visible"
+            }
+        }]
+        censored = censor_tokens(response)
+        assert censored[0]["Authenticate"]["session_token"] == "adbs_1234...cdef"
+        assert censored[0]["Authenticate"]["refresh_token"] == "adbr_abcd...7890"
+        assert censored[0]["Authenticate"]["other_field"] == "visible"
+
+        # Short tokens
+        response = [{
+            "Authenticate": {
+                "status": 0,
+                "session_token": "adbs_1234",
+                "refresh_token": "short"
+            }
+        }]
+        censored = censor_tokens(response)
+        assert censored[0]["Authenticate"]["session_token"] == "adbs_..."
+        assert censored[0]["Authenticate"]["refresh_token"] == "..."
+
+        # RefreshToken command
+        response = [{
+            "RefreshToken": {
+                "status": 0,
+                "session_token": "adbs_longertokentest"
+            }
+        }]
+        censored = censor_tokens(response)
+        assert censored[0]["RefreshToken"]["session_token"] == "adbs_long...test"

--- a/test/test_Utils.py
+++ b/test/test_Utils.py
@@ -59,6 +59,7 @@ class TestUtils():
         censored = censor_tokens(response)
         assert censored[0]["RefreshToken"]["session_token"] == "adbs_long...test"
 
+
 class TestUtilsSummaryNormalization():
 
     def test_summary_normalization(self):


### PR DESCRIPTION
Closes #545

This PR fixes the issue where `refresh_token` and `session_token` information was exposed in logs when a connection error or failed query occurred. It introduces a `censor_tokens` utility inside the logging functions of `Connector.py`, `Utils.py`, and `CommonLibrary.py` to mask the tokens (e.g., `adbr_...nu` instead of showing the full token).