### PR TITLE
feat(connector): add boolean parameter to connect at construction

### DIFF
--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -153,7 +153,8 @@ class Connector(object):
                  retry_interval_seconds=DEFAULT_RETRY_INTERVAL_SECONDS,
                  retry_max_attempts=DEFAULT_RETRY_MAX_ATTEMPTS,
                  config: Optional[Configuration] = None,
-                 key: Optional[str] = None):
+                 key: Optional[str] = None,
+                 connect: bool = False):
         """
         Constructor for the Connector class.
         """
@@ -209,6 +210,9 @@ class Connector(object):
         # One time flag to indicate if we ever connected,
         # to prevent logging of connection errors on first connect.
         self._ever_connected = False
+
+        if connect:
+            self.connect()
 
     def authenticate(self, shared_data, user, password, token):
         """

--- a/test/test_Session.py
+++ b/test/test_Session.py
@@ -265,3 +265,28 @@ class TestSession():
         resp, blobs = db.query([{'GetSchema': {}}], [])
         print(f"{resp=}")
         assert enable_mock == False, "Authentication query was not invoked"
+
+    def test_connect_at_construction(self, monkeypatch):
+        # We want to test that connect() is called when connect=True.
+        # mock connect so it doesn't fail on missing server
+        def mock_connect(self):
+            self.connected = True
+        monkeypatch.setattr(Connector, "connect", mock_connect)
+
+        new_db = Connector(
+            dbinfo.DB_TCP_HOST,
+            dbinfo.DB_TCP_PORT,
+            dbinfo.DB_USER,
+            dbinfo.DB_PASSWORD,
+            ca_cert=dbinfo.CA_CERT,
+            connect=True)
+        assert getattr(new_db, "connected", False) == True
+
+        # also test default behavior
+        new_db_lazy = Connector(
+            dbinfo.DB_TCP_HOST,
+            dbinfo.DB_TCP_PORT,
+            dbinfo.DB_USER,
+            dbinfo.DB_PASSWORD,
+            ca_cert=dbinfo.CA_CERT)
+        assert getattr(new_db_lazy, "connected", False) == False


### PR DESCRIPTION
Closes #369

Added a `connect` boolean parameter to `Connector.__init__` which defaults to `False` to preserve existing behavior. When `connect=True` is provided, the Connector will automatically call `self.connect()` upon initialization, restoring the old behavior.