### PR TITLE
fix(parallel): handle aborted batches in map_response_to_handler

### DIFF
--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -348,7 +348,8 @@ def map_response_to_handler(handler, query, query_blobs,  response, response_blo
     # We could potentially always call this handler function
     # and let the user deal with the error cases.
     blobs_returned = 0
-    for i in range(math.ceil(len(query) / commands_per_query)):
+    limit = len(response) if issubclass(type(response), list) else len(query)
+    for i in range(math.ceil(limit / commands_per_query)):
         start = i * commands_per_query
         end = start + commands_per_query
         blobs_start = i * blobs_per_query

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -348,7 +348,8 @@ def map_response_to_handler(handler, query, query_blobs,  response, response_blo
     # We could potentially always call this handler function
     # and let the user deal with the error cases.
     blobs_returned = 0
-    limit = len(response) if isinstance(response, list) else len(query)
+    is_list = isinstance(response, list)
+    limit = len(response) if is_list else len(query)
     for i in range(math.ceil(limit / commands_per_query)):
         start = i * commands_per_query
         end = min(start + commands_per_query, limit)
@@ -356,7 +357,7 @@ def map_response_to_handler(handler, query, query_blobs,  response, response_blo
         blobs_end = blobs_start + blobs_per_query
 
         b_count = 0
-        if isinstance(response, list):
+        if is_list:
             for req, resp in zip(query[start:end], response[start:end]):
                 for k in req:
                     blob_returning_commands = ["FindImage", "FindBlob", "FindVideo",

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -351,12 +351,12 @@ def map_response_to_handler(handler, query, query_blobs,  response, response_blo
     limit = len(response) if isinstance(response, list) else len(query)
     for i in range(math.ceil(limit / commands_per_query)):
         start = i * commands_per_query
-        end = start + commands_per_query
+        end = min(start + commands_per_query, limit)
         blobs_start = i * blobs_per_query
         blobs_end = blobs_start + blobs_per_query
 
         b_count = 0
-        if issubclass(type(response), list):
+        if isinstance(response, list):
             for req, resp in zip(query[start:end], response[start:end]):
                 for k in req:
                     blob_returning_commands = ["FindImage", "FindBlob", "FindVideo",
@@ -370,8 +370,8 @@ def map_response_to_handler(handler, query, query_blobs,  response, response_blo
         handler(
             query[start:end],
             query_blobs[blobs_start:blobs_end],
-            response[start:end] if issubclass(
-                type(response), list) else response,
+            response[start:end] if isinstance(
+                response, list) else response,
             response_blobs[blobs_returned:blobs_returned + b_count] if
             len(response_blobs) >= blobs_returned + b_count else None,
             None if cmd_index_offset is None else cmd_index_offset + i)

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -348,7 +348,7 @@ def map_response_to_handler(handler, query, query_blobs,  response, response_blo
     # We could potentially always call this handler function
     # and let the user deal with the error cases.
     blobs_returned = 0
-    limit = len(response) if issubclass(type(response), list) else len(query)
+    limit = len(response) if isinstance(response, list) else len(query)
     for i in range(math.ceil(limit / commands_per_query)):
         start = i * commands_per_query
         end = start + commands_per_query

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -180,7 +180,7 @@ class QGSetPersonAndImages(Subscriptable):
 
 # Fake DB query.
 def mock_query(self, request, blobs):
-    self.response = [{k: {"status": 0} for k, v in c.items()} for c in request]
+    self.response = [{k: {"status": 0} for k in c} for c in request]
     return self.response, []
 
 # Fake DB query. Depending in the transaction, return a response increasing number of images.

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -397,3 +397,80 @@ class TestResponseHandler():
                       numthreads=31,
                       stats=True)
         assert querier.error_counter != 0
+
+    def test_issue_181_example(self, db, monkeypatch):
+        from aperturedb.QueryGenerator import QueryGenerator
+        from aperturedb.ParallelQuery import ParallelQuery
+        from aperturedb.Connector import Connector
+
+        class UpdateAndCheckImageLabel(QueryGenerator):
+            def __init__(self, imgids, field, new_labels, changed_ids):
+                self.field = field
+                self.imgids = imgids
+                self.new_labels = new_labels
+                self.changed_ids = changed_ids
+
+            def __len__(self):
+                return len(self.imgids)
+
+            def getitem(self, idx):
+                id = self.imgids[idx]
+                label = self.new_labels[idx]
+
+                q = [{
+                    "FindImage": {
+                        "blobs": False,
+                        "constraints": {
+                            "image_id": [ "==", id ],
+                            self.field: ["!=", label]
+                        },
+                        "results": {
+                            "count": True,
+                            "list": ["image_id"]
+                        }
+                    }
+                 }, {
+                     "UpdateImage": {
+                         "properties": {
+                             self.field: label
+                         }
+                     }
+                 }]
+                return q, []
+            
+            def response_handler(self, q, b ,r, r_b ):
+                try:
+                    count  = r[0]["FindImage"].get("count", 0)
+                    if count == 1:
+                        img_id = r[0]["FindImage"]["entities"][0]["image_id"]
+                        self.changed_ids.append(img_id)
+                except Exception as e:
+                    print(f"Response Handler Error: {r}")
+                    print(f"Exception: {e}")
+                    raise e
+
+        changed_ids = []
+        imgids = [1, 2, 3]
+        field = "image_type"
+        new_labels = ["Silo", "Silo", "Silo"]
+
+        def mock_query(self, request, blobs):
+            responses = []
+            for c in request:
+                if "FindImage" in c:
+                    responses.append({
+                        "FindImage": {
+                            "status": 0,
+                            "count": 1,
+                            "entities": [{"image_id": "img1"}]
+                        }
+                    })
+            return responses, []
+
+        monkeypatch.setattr(Connector, "query", mock_query)
+
+        generator = UpdateAndCheckImageLabel(imgids, field, new_labels, changed_ids)
+        querier = ParallelQuery(db)
+        querier.query(generator, numthreads=1, batchsize=2, stats=False)
+
+        assert len(changed_ids) == 3

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -479,6 +479,8 @@ class TestResponseHandler():
             return responses, []
 
         monkeypatch.setattr(Connector, "query", mock_query)
+        monkeypatch.setattr(Connector, "last_query_ok", lambda self: True)
+        monkeypatch.setattr(Connector, "clone", lambda self: self)
 
         generator = UpdateAndCheckImageLabel(
             imgids, field, new_labels, changed_ids)

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -421,7 +421,7 @@ class TestResponseHandler():
                     "FindImage": {
                         "blobs": False,
                         "constraints": {
-                            "image_id": [ "==", id ],
+                            "image_id": ["==", id],
                             self.field: ["!=", label]
                         },
                         "results": {
@@ -429,16 +429,16 @@ class TestResponseHandler():
                             "list": ["image_id"]
                         }
                     }
-                 }, {
-                     "UpdateImage": {
-                         "properties": {
-                             self.field: label
-                         }
-                     }
-                 }]
+                }, {
+                    "UpdateImage": {
+                        "properties": {
+                            self.field: label
+                        }
+                    }
+                }]
                 return q, []
-            
-            def response_handler(self, q, b ,r, r_b ):
+
+            def response_handler(self, q, b, r, r_b):
                 try:
                     count  = r[0]["FindImage"].get("count", 0)
                     if count == 1:
@@ -469,7 +469,8 @@ class TestResponseHandler():
 
         monkeypatch.setattr(Connector, "query", mock_query)
 
-        generator = UpdateAndCheckImageLabel(imgids, field, new_labels, changed_ids)
+        generator = UpdateAndCheckImageLabel(
+            imgids, field, new_labels, changed_ids)
         querier = ParallelQuery(db)
         querier.query(generator, numthreads=1, batchsize=2, stats=False)
 

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -414,14 +414,14 @@ class TestResponseHandler():
                 return len(self.imgids)
 
             def getitem(self, idx):
-                id = self.imgids[idx]
+                image_id = self.imgids[idx]
                 label = self.new_labels[idx]
 
                 q = [{
                     "FindImage": {
                         "blobs": False,
                         "constraints": {
-                            "image_id": ["==", id],
+                            "image_id": ["==", image_id],
                             self.field: ["!=", label]
                         },
                         "results": {
@@ -447,7 +447,7 @@ class TestResponseHandler():
                 except Exception as e:
                     print(f"Response Handler Error: {r}")
                     print(f"Exception: {e}")
-                    raise e
+                    raise
 
         changed_ids = []
         imgids = [1, 2, 3]
@@ -456,7 +456,10 @@ class TestResponseHandler():
 
         def mock_query(self, request, blobs):
             responses = []
-            for c in request:
+            for i, c in enumerate(request):
+                # simulate aborting after 2 commands (1 pair out of a batch)
+                if i >= 2:
+                    break
                 if "FindImage" in c:
                     responses.append({
                         "FindImage": {
@@ -465,6 +468,14 @@ class TestResponseHandler():
                             "entities": [{"image_id": "img1"}]
                         }
                     })
+                elif "UpdateImage" in c:
+                    responses.append({
+                        "UpdateImage": {
+                            "status": 0
+                        }
+                    })
+            self.response = responses
+            self.blobs = []
             return responses, []
 
         monkeypatch.setattr(Connector, "query", mock_query)
@@ -474,4 +485,4 @@ class TestResponseHandler():
         querier = ParallelQuery(db)
         querier.query(generator, numthreads=1, batchsize=2, stats=False)
 
-        assert len(changed_ids) == 3
+        assert len(changed_ids) == 2

--- a/test/test_ResponseHandler.py
+++ b/test/test_ResponseHandler.py
@@ -180,7 +180,7 @@ class QGSetPersonAndImages(Subscriptable):
 
 # Fake DB query.
 def mock_query(self, request, blobs):
-    self.response = [{k: {"status": 0} for c in request for k, v in c.items()}]
+    self.response = [{k: {"status": 0} for k, v in c.items()} for c in request]
     return self.response, []
 
 # Fake DB query. Depending in the transaction, return a response increasing number of images.


### PR DESCRIPTION
Closes #181

If a batch query aborts prematurely, the database returns a response shorter than the number of queries issued. `map_response_to_handler` was looping over the original query length, which resulted in passing empty lists `[]` as the response `r` for the queries that were not executed.

This PR changes the loop to iterate based on the length of `response`, preventing `IndexError` (or `KeyError`) inside user-defined `response_handler`s when queries contain more than one command and fail mid-batch.