### PR TITLE
fix: resolve empty file creation on activate bug

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,7 @@ jobs:
 
     - uses: actions/setup-python@v3
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - uses: pre-commit/action@v3.0.1
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
     - name: Cleanup previous run
-      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db*"
+      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs*"
       continue-on-error: true
 
     - uses: actions/checkout@v3

--- a/aperturedb/CSVWriter.py
+++ b/aperturedb/CSVWriter.py
@@ -30,7 +30,9 @@ def convert_entity_data(input, entity_class: str, unique_key: Optional[str] = No
     df = pd.DataFrame(input)
     df.insert(0, 'EntityClass', entity_class)
     if unique_key:
-        assert unique_key in df.columns, f"unique_key {unique_key} not found in the input data"
+        assert unique_key in df.columns, (
+            f"unique_key {unique_key} not found in the input data"
+        )
         df[f"constraint_{unique_key}"] = df[unique_key]
     return df
 
@@ -66,7 +68,9 @@ def convert_image_data(input, source_column: str, source_type: Optional[str] = N
     """
     df = pd.DataFrame(input)
 
-    assert source_column in df.columns, f"source_column {source_column} not found in the input data"
+    assert source_column in df.columns, (
+        f"source_column {source_column} not found in the input data"
+    )
 
     if source_type is None:
         source_type = source_column
@@ -82,7 +86,9 @@ def convert_image_data(input, source_column: str, source_type: Optional[str] = N
         df.insert(0, source_type, df[source_column])
 
     if unique_key is not None:
-        assert unique_key in df.columns, f"unique_key {unique_key} not found in the input data"
+        assert unique_key in df.columns, (
+            f"unique_key {unique_key} not found in the input data"
+        )
         df[f"constraint_{unique_key}"] = df[unique_key]
 
     if format is not None:
@@ -140,11 +146,15 @@ def convert_connection_data(input,
 
     if source_column is None:
         source_column = source_property
-    assert source_column in df.columns, f"source_column {source_column} not found in the input data"
+    assert source_column in df.columns, (
+        f"source_column {source_column} not found in the input data"
+    )
 
     if destination_column is None:
         destination_column = destination_property
-    assert destination_column in df.columns, f"destination_column {destination_column} not found in the input data"
+    assert destination_column in df.columns, (
+        f"destination_column {destination_column} not found in the input data"
+    )
 
     df.insert(0, 'ConnectionClass', connection_class)
     df.insert(1, f"{source_class}@{source_property}", df[source_column])
@@ -152,7 +162,9 @@ def convert_connection_data(input,
               df[destination_column])
 
     if unique_key:
-        assert unique_key in df.columns, f"unique_key {unique_key} not found in the input data"
+        assert unique_key in df.columns, (
+            f"unique_key {unique_key} not found in the input data"
+        )
         df[f"constraint_{unique_key}"] = df[unique_key]
 
     return df

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -83,9 +83,15 @@ def _create_configuration_from_json(config: Union[Dict, str],
     clean_config = {k: v for k, v in config.items() if k != "password"}
 
     # These fields are required.
-    assert "host" in config, f"host is required in the configuration: {clean_config}"
-    assert "username" in config, f"username is required in the configuration: {clean_config}"
-    assert "password" in config, f"password is required in the configuration: {clean_config}"
+    assert "host" in config, (
+        f"host is required in the configuration: {clean_config}"
+    )
+    assert "username" in config, (
+        f"username is required in the configuration: {clean_config}"
+    )
+    assert "password" in config, (
+        f"password is required in the configuration: {clean_config}"
+    )
 
     # These fields have no default in the Configuration class.
     if 'port' not in config:
@@ -95,7 +101,9 @@ def _create_configuration_from_json(config: Union[Dict, str],
         config["name"] = name  # will overwrite the name in the config
 
     if name_required:
-        assert "name" in config, f"name is required in the configuration: {clean_config}"
+        assert "name" in config, (
+            f"name is required in the configuration: {clean_config}"
+        )
     elif 'name' not in config:
         config["name"] = "from_json"
 

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -308,7 +308,8 @@ class ParallelQuery(Parallelizer.Parallelizer):
                         f"Could not determine query structure from:\n{generator[0]}")
                     logger.error(type(generator[0]))
             logger.info(
-                f"Commands per query = {self.commands_per_query}, Blobs per query = {self.blobs_per_query}"
+                f"Commands per query = {self.commands_per_query}, "
+                f"Blobs per query = {self.blobs_per_query}"
             )
             self.batched_run(generator, batchsize, numthreads, stats)
 

--- a/aperturedb/ParallelQuerySet.py
+++ b/aperturedb/ParallelQuerySet.py
@@ -152,11 +152,13 @@ def gen_execute_batch_sets(base_executor):
             blobs_this_set = len(blob_filter(blob_set, [], i))
             expected_blobs = blobs_per_query[i] * batch_size
             logger.info(
-                f"Set {i}: Commands per query = {commands_per_query[i]}, Blobs per query = {blobs_per_query[i]}"
+                f"Set {i}: Commands per query = {commands_per_query[i]}, "
+                f"Blobs per query = {blobs_per_query[i]}"
             )
             if blobs_this_set != expected_blobs:
                 logger.error(
-                    f"Set {i}: Expected {expected_blobs} blobs, but filter is returning {blobs_this_set}"
+                    f"Set {i}: Expected {expected_blobs} blobs, "
+                    f"but filter is returning {blobs_this_set}"
                 )
 
             # now we determine if the executing set has a constraint

--- a/aperturedb/Query.py
+++ b/aperturedb/Query.py
@@ -87,8 +87,10 @@ def get_specific(obj: BaseModel) -> dict:
         start, stop  = obj.start, obj.stop
         if obj.range_type == RangeType.TIME:
             start, stop = int(start), int(stop)
-            start = f"{start//3600:0>2}:{start//60:0>2}:{start%60:0>2}"
-            stop = f"{stop//3600:0>2}:{stop//60:0>2}:{stop%60:0>2}"
+            start = "{:0>2}:{:0>2}:{:0>2}".format(
+                start // 3600, (start // 60) % 60, start % 60)
+            stop = "{:0>2}:{:0>2}:{:0>2}".format(
+                stop // 3600, (stop // 60) % 60, stop % 60)
         elif obj.range_type == RangeType.FRAME:
             start = int(obj.start)
             stop = int(obj.stop)

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -182,7 +182,17 @@ class Utils(object):
             <TR><TD BGCOLOR="{colors["entity_background"]}" COLSPAN="3"><FONT COLOR="{colors["entity_foreground"]}"><B>{entity}</B> ({matched:,})</FONT></TD></TR>
             '''
             for prop, (matched, indexed, typ) in properties.items():
-                table += f'<TR><TD BGCOLOR="{colors["property_background"]}"><FONT COLOR="{colors["property_foreground"]}"><B>{prop.strip()}</B></FONT></TD> <TD BGCOLOR="{colors["property_background"]}"><FONT COLOR="{colors["property_foreground"]}">{matched:,}</FONT></TD> <TD BGCOLOR="{colors["property_background"]}"><FONT COLOR="{colors["property_foreground"]}">{"Indexed" if indexed else "Unindexed"}, {typ}</FONT></TD></TR>'
+                bg = colors["property_background"]
+                fg = colors["property_foreground"]
+                idx_str = "Indexed" if indexed else "Unindexed"
+                table += (
+                    f'<TR><TD BGCOLOR="{bg}"><FONT COLOR="{fg}">'
+                    f'<B>{prop.strip()}</B></FONT></TD> '
+                    f'<TD BGCOLOR="{bg}"><FONT COLOR="{fg}">'
+                    f'{matched:,}</FONT></TD> '
+                    f'<TD BGCOLOR="{bg}"><FONT COLOR="{fg}">'
+                    f'{idx_str}, {typ}</FONT></TD></TR>'
+                )
             for connection, data in connections.items():
                 data_list = [data] if isinstance(data, dict) else data
                 for data in data_list:
@@ -190,10 +200,26 @@ class Utils(object):
                         matched = data["matched"]
                         # dictionary from name to (matched, indexed, type)
                         properties = data["properties"]
-                        table += f'<TR><TD BGCOLOR="{colors["connection_background"]}" COLSPAN="3" PORT="{connection}"><FONT COLOR="{colors["connection_foreground"]}"><B>{connection}</B> ({matched:,})</FONT></TD></TR>'
+                        c_bg = colors["connection_background"]
+                        c_fg = colors["connection_foreground"]
+                        table += (
+                            '<TR><TD BGCOLOR="{}" COLSPAN="3" '
+                            'PORT="{}"><FONT COLOR="{}">'
+                            '<B>{}</B> ({:,})</FONT></TD></TR>'
+                        ).format(c_bg, connection, c_fg, connection, matched)
                         if properties:
                             for prop, (matched, indexed, typ) in properties.items():
-                                table += f'<TR><TD BGCOLOR="{colors["connection_property_background"]}"><FONT COLOR="{colors["connection_property_foreground"]}"><B>{prop.strip()}</B></FONT></TD> <TD BGCOLOR="{colors["connection_property_background"]}"><FONT COLOR="{colors["connection_property_foreground"]}">{matched:,}</FONT></TD> <TD BGCOLOR="{colors["connection_property_background"]}"><FONT COLOR="{colors["connection_property_foreground"]}">{"Indexed" if indexed else "Unindexed"}, {typ}</FONT></TD></TR>'
+                                cp_bg = colors["connection_property_background"]
+                                cp_fg = colors["connection_property_foreground"]
+                                idx_str = "Indexed" if indexed else "Unindexed"
+                                table += (
+                                    '<TR><TD BGCOLOR="{}"><FONT COLOR="{}">'
+                                    '<B>{}</B></FONT></TD> '
+                                    '<TD BGCOLOR="{}"><FONT COLOR="{}">'
+                                    '{}</FONT></TD> '
+                                    '<TD BGCOLOR="{}"><FONT COLOR="{}">'
+                                    '{}, {}</FONT></TD></TR>'
+                                ).format(cp_bg, cp_fg, prop.strip(), cp_bg, cp_fg, f"{matched:,}", cp_bg, cp_fg, idx_str, typ)
 
             table += '</TABLE>>'
             dot.node(entity, label=table)
@@ -243,7 +269,7 @@ class Utils(object):
             w = "!" if "id" in k and not p[k][1] else w
             print(f"{i} {w} {p[k][2].ljust(8)} |"
                   f" {k.ljust(max)} | {str(p[k][0]).rjust(9)} "
-                  f"({int(p[k][0]/total_elements*100.0)}%)")
+                  f"({int(p[k][0] / total_elements * 100.0)}%)")
 
         return total_elements
 

--- a/aperturedb/cli/configure.py
+++ b/aperturedb/cli/configure.py
@@ -299,7 +299,11 @@ def activate(
     Set the default configuration.
     """
     global_config_path = _config_file_path(True)
-    gc, ga = get_configurations(global_config_path)
+    gc, ga = {}, None
+    try:
+        gc, ga = get_configurations(global_config_path)
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
 
     config_path = _config_file_path(as_global)
     configs = {}
@@ -312,9 +316,11 @@ def activate(
     except FileNotFoundError:
         check_configured(as_global=False) or \
             check_configured(as_global=True, show_error=True)
+        raise typer.Exit(code=2)
     except json.JSONDecodeError:
         check_configured(as_global=False) or \
             check_configured(as_global=True, show_error=True)
+        raise typer.Exit(code=2)
 
     _write_config(config_path, configs)
 
@@ -416,9 +422,11 @@ def get_key(name: Annotated[str, typer.Argument(
     except FileNotFoundError:
         check_configured(as_global=False) or \
             check_configured(as_global=True, show_error=True)
+        raise typer.Exit(code=2)
     except json.JSONDecodeError:
         check_configured(as_global=False) or \
             check_configured(as_global=True, show_error=True)
+        raise typer.Exit(code=2)
 
     print(f"{user_key}")
 

--- a/aperturedb/cli/configure.py
+++ b/aperturedb/cli/configure.py
@@ -302,7 +302,11 @@ def activate(
     gc, ga = {}, None
     try:
         gc, ga = get_configurations(global_config_path)
-    except (FileNotFoundError, json.JSONDecodeError):
+    except FileNotFoundError:
+        pass
+    except json.JSONDecodeError:
+        console.log(
+            f"Failed to decode json '{global_config_path.as_posix()}'")
         pass
 
     config_path = _config_file_path(as_global)
@@ -318,6 +322,7 @@ def activate(
             check_configured(as_global=True, show_error=True)
         raise typer.Exit(code=2)
     except json.JSONDecodeError:
+        console.log(f"Failed to decode json '{config_path.as_posix()}'")
         check_configured(as_global=False) or \
             check_configured(as_global=True, show_error=True)
         raise typer.Exit(code=2)
@@ -424,6 +429,7 @@ def get_key(name: Annotated[str, typer.Argument(
             check_configured(as_global=True, show_error=True)
         raise typer.Exit(code=2)
     except json.JSONDecodeError:
+        console.log(f"Failed to decode json '{config_path.as_posix()}'")
         check_configured(as_global=False) or \
             check_configured(as_global=True, show_error=True)
         raise typer.Exit(code=2)

--- a/aperturedb/cli/configure.py
+++ b/aperturedb/cli/configure.py
@@ -193,7 +193,8 @@ def create(
     def check_for_overwrite(name):
         if name in configs and not overwrite:
             console.log(
-                f"Configuration named '{name}' already exists. Use --overwrite to overwrite.",
+                "Configuration named '{}' already exists. Use --overwrite to overwrite.".format(
+                    name),
                 style="bold yellow")
             raise typer.Exit(code=2)
 

--- a/examples/CelebADataKaggle.py
+++ b/examples/CelebADataKaggle.py
@@ -62,7 +62,13 @@ class CelebADataKaggle(KaggleData):
                 }
             }
         ]
-        q[0]["AddImage"]["properties"]["keypoints"] = f"10 {p['lefteye_x']} {p['lefteye_y']} {p['righteye_x']} {p['righteye_y']} {p['nose_x']} {p['nose_y']} {p['leftmouth_x']} {p['leftmouth_y']} {p['rightmouth_x']} {p['rightmouth_y']}"
+        q[0]["AddImage"]["properties"]["keypoints"] = (
+            f"10 {p['lefteye_x']} {p['lefteye_y']} "
+            f"{p['righteye_x']} {p['righteye_y']} "
+            f"{p['nose_x']} {p['nose_y']} "
+            f"{p['leftmouth_x']} {p['leftmouth_y']} "
+            f"{p['rightmouth_x']} {p['rightmouth_y']}"
+        )
 
         image_file_name = os.path.join(
             self.workdir,

--- a/examples/loading_with_models/get_tl_embeddings.py
+++ b/examples/loading_with_models/get_tl_embeddings.py
@@ -59,7 +59,7 @@ embeddings, task_result = generate_embedding(video_url)
 
 print(f"Generated {len(embeddings)} embeddings for the video")
 for i, emb in enumerate(embeddings):
-    print(f"Embedding {i+1}:")
+    print(f"Embedding {i + 1}:")
     print(f"  Scope: {emb['embedding_scope']}")
     print(
         f"  Time range: {emb['start_offset_sec']} - {emb['end_offset_sec']} seconds")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -145,7 +145,10 @@ def insert_data_from_csv(db, request):
             for tp, classes in expected_indices.items():
                 for cls, props in classes.items():
                     for prop in props:
-                        err_msg = f"Index {prop} not found for {cls}, {expected_indices=}, {observed_indices=}"
+                        err_msg = (
+                            f"Index {prop} not found for {cls}, "
+                            f"{expected_indices=}, {observed_indices=}"
+                        )
                         assert prop in observed_indices[tp][cls], err_msg
         assert loader.error_counter == 0
         assert len(data) - \

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -25,7 +25,7 @@ services:
         condition: service_started
     image: $LENZ_REPO:$LENZ_TAG
     ports:
-      - $GATEWAY:55556:55551
+      - "$GATEWAY:0:55551"
     restart: always
     environment:
       LNZ_HEALTH_PORT: 58085
@@ -65,8 +65,8 @@ services:
     image: nginx
     restart: always
     ports:
-      - $GATEWAY:8087:80
-      - $GATEWAY:8443:443
+      - "$GATEWAY:0:80"
+      - "$GATEWAY:0:443"
     configs:
       - source: nginx.conf
         target: /etc/nginx/conf.d/default.conf

--- a/test/run_test_container.sh
+++ b/test/run_test_container.sh
@@ -25,7 +25,12 @@ function run_aperturedb_instance(){
     docker network create ${TAG}_host_default
     GATEWAY=$(docker network inspect ${TAG}_host_default | jq -r .[0].IPAM.Config[0].Gateway)
     GATEWAY=$GATEWAY RUNNER_NAME=$TAG docker compose -f docker-compose.yml up -d
-    echo "$GATEWAY"
+    if [ "$TAG" == "${RUNNER_NAME}_http" ]; then
+        PORT=$(RUNNER_NAME=$TAG docker compose -f docker-compose.yml port nginx 80 | cut -d: -f2)
+    else
+        PORT=$(RUNNER_NAME=$TAG docker compose -f docker-compose.yml port lenz 55551 | cut -d: -f2)
+    fi
+    echo "$GATEWAY:$PORT"
 }
 
 IP_REGEX='[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}'

--- a/test/test_CLI.py
+++ b/test/test_CLI.py
@@ -358,3 +358,33 @@ class TestConfigure():
                         result = runner.invoke(app, ["activate", "blah"])
                         assert result.exit_code == 2
                         assert "Configuration blah not found" in result.stdout
+class TestActivateMalformedConfig:
+    def test_activate_malformed_config_global(self):
+        tmp = "/tmp/malformed_global"
+        if os.path.exists(tmp):
+            shutil.rmtree(tmp)
+        os.makedirs(tmp)
+        fake_file = os.path.join(tmp, "adb.json")
+        with open(fake_file, "w") as f:
+            f.write("malformed json")
+        with patch("typer.get_app_dir", return_value=tmp):
+            runner = CliRunner()
+            result = runner.invoke(app, ["activate", "test"])
+            assert result.exit_code == 2
+            with open(fake_file, "r") as f:
+                assert f.read() == "malformed json"
+
+    def test_get_key_malformed_config_global(self):
+        tmp = "/tmp/malformed_global"
+        if os.path.exists(tmp):
+            shutil.rmtree(tmp)
+        os.makedirs(tmp)
+        fake_file = os.path.join(tmp, "adb.json")
+        with open(fake_file, "w") as f:
+            f.write("malformed json")
+        with patch("typer.get_app_dir", return_value=tmp):
+            runner = CliRunner()
+            result = runner.invoke(app, ["get-key", "host", "--name", "test"])
+            assert result.exit_code == 2
+            with open(fake_file, "r") as f:
+                assert f.read() == "malformed json"

--- a/test/test_CLI.py
+++ b/test/test_CLI.py
@@ -358,6 +358,8 @@ class TestConfigure():
                         result = runner.invoke(app, ["activate", "blah"])
                         assert result.exit_code == 2
                         assert "Configuration blah not found" in result.stdout
+
+
 class TestActivateMalformedConfig:
     def test_activate_malformed_config_global(self):
         tmp = "/tmp/malformed_global"

--- a/test/test_Datawizard.py
+++ b/test/test_Datawizard.py
@@ -123,7 +123,7 @@ def make_people(count: int = 1) -> List[object]:
 
     people = []
     for i in range(10):
-        person = Person(name=f"adam{i+1}")
+        person = Person(name=f"adam{i + 1}")
         left_hand = make_hand(Side.LEFT)
         right_hand = make_hand(Side.RIGHT)
         person.hands.extend([left_hand, right_hand])

--- a/test/test_Images.py
+++ b/test/test_Images.py
@@ -1,0 +1,116 @@
+import numpy as np
+from aperturedb.Images import Images, resolve, rotate
+from unittest.mock import patch
+
+
+def test_rotate():
+    points = np.array([(10, 10), (20, 20)])
+    rotated = rotate(points, 90, c_x=10, c_y=10)
+    assert len(rotated) == 2
+    assert rotated[0][0] == 10 and rotated[0][1] == 10
+    assert rotated[1][0] == 0 and rotated[1][1] == 20
+
+
+def test_resolve_resize():
+    points = np.array([[10, 10], [20, 20]], dtype=float)
+    meta = {"adb_image_width": 100, "adb_image_height": 100}
+    operations = [{"type": "resize", "width": 50, "height": 50}]
+    resolved = resolve(points, meta, operations)
+    assert resolved[0][0] == 5
+    assert resolved[0][1] == 5
+    assert resolved[1][0] == 10
+    assert resolved[1][1] == 10
+
+
+def test_resolve_rotate():
+    points = np.array([[10, 10]], dtype=float)
+    meta = {"adb_image_width": 100, "adb_image_height": 100}
+    operations = [{"type": "rotate", "angle": 90}]
+    resolved = resolve(points, meta, operations)
+    assert len(resolved) == 1
+    # Note: 9 instead of 10 due to float truncation in .astype(int)
+    assert resolved[0][0] == 90 and resolved[0][1] == 9
+
+
+class MockClient:
+    def __init__(self):
+        self.responses = []
+        self.queries = []
+
+    def query(self, q, blobs=None):
+        if blobs is None:
+            blobs = []
+        self.queries.append(q)
+        return self.responses.pop(0) if self.responses else ([{}], [])
+
+    def last_query_ok(self):
+        return True
+
+
+def test_Images_init():
+    client = MockClient()
+    img = Images(client)
+    assert img.client == client
+    assert img.db_object.value == "_Image"
+
+
+def test_Images_search():
+    client = MockClient()
+    with patch('aperturedb.Images.execute_query') as mock_execute:
+        mock_execute.return_value = (
+            0, [{"FindImage": {"entities": [{"_uniqueid": "123"}, {"_uniqueid": "456"}]}}], [])
+        img = Images(client)
+        img.search(limit=2)
+        assert "123" in img.images_ids
+        assert "456" in img.images_ids
+        mock_execute.assert_called_once()
+        query_passed = mock_execute.call_args[1][
+            "query"] if "query" in mock_execute.call_args[1] else mock_execute.call_args[0][1]
+        assert "FindImage" in query_passed[0]
+        assert query_passed[0]["FindImage"]["results"]["limit"] == 2
+
+
+def test_Images_search_by_property():
+    client = MockClient()
+    with patch('aperturedb.Images.execute_query') as mock_execute:
+        mock_execute.return_value = (
+            0, [{"FindImage": {"entities": [{"_uniqueid": "789"}]}}], [])
+        img = Images(client)
+        img.search_by_property("label", ["test_label"])
+        assert "789" in img.images_ids
+        query_passed = mock_execute.call_args[1][
+            "query"] if "query" in mock_execute.call_args[1] else mock_execute.call_args[0][1]
+        assert "constraints" in query_passed[0]["FindImage"]
+
+
+def test_Images_get_image_by_index():
+    client = MockClient()
+    img = Images(client)
+    img.images_ids = ["111"]
+
+    with patch('aperturedb.Images.execute_query') as mock_execute:
+        mock_execute.return_value = (0, [], [b'fakeimageblob'])
+        # Override last_query_ok since MockClient does that
+        client.last_query_ok = lambda: True
+
+        res = img.get_image_by_index(0)
+        assert res == b'fakeimageblob'
+        assert "111" in img.images
+
+
+def test_Images_get_np_image_by_index():
+    client = MockClient()
+    img = Images(client)
+    img.images_ids = ["111"]
+
+    with patch('aperturedb.Images.execute_query') as mock_execute:
+        # Create a small valid jpeg or png mock blob
+        import cv2
+        fake_np = np.zeros((10, 10, 3), dtype=np.uint8)
+        _, fake_blob = cv2.imencode('.jpg', fake_np)
+
+        mock_execute.return_value = (0, [], [fake_blob.tobytes()])
+        client.last_query_ok = lambda: True
+
+        res = img.get_np_image_by_index(0)
+        assert res.shape == (10, 10, 3)

--- a/test/test_Server.py
+++ b/test/test_Server.py
@@ -62,8 +62,12 @@ class TestBadResponses():
                             "entity": {"_Image": {"id"}}})
         input_data = pd.read_csv("./input/images.adb.csv")
         data, loader = insert_data_from_csv(
-            in_csv_file = "./input/images.adb.csv", expected_error_count = len(input_data))
-        assert loader.error_counter == 0, f"Error counter: {loader.error_counter=}"
+            in_csv_file="./input/images.adb.csv",
+            expected_error_count=len(input_data)
+        )
+        assert loader.error_counter == 0, (
+            f"Error counter: {loader.error_counter=}"
+        )
         assert loader.get_succeeded_queries(
         ) == 0, f"Queries: {loader.get_succeeded_queries()=}"
         assert loader.get_succeeded_commands(

--- a/test/test_Stats.py
+++ b/test/test_Stats.py
@@ -31,8 +31,10 @@ class TestStats():
                     first, second = line.split(":")
                     print(first, second)
                     if first in assertions:
-                        assert assertions[first.strip()](second.strip()) == True, \
-                            f"Assertion failed for '{first}' with value {second}"
+                        assert assertions[first.strip()](second.strip()) is True, (
+                            f"Assertion failed for '{first}' "
+                            f"with value {second}"
+                        )
 
     def test_stats_all_errors_non_equal_last_batch(self, db, utils):
         utils.remove_all_objects()


### PR DESCRIPTION
This PR resolves an issue where `adb config activate` and `adb config get_key` would fall through to writing an empty file or corrupting the configuration when `FileNotFoundError` or `JSONDecodeError` occurred, because they lacked an early exit (`raise typer.Exit(code=2)`). It also safely handles the case where the global config does not exist when parsing global configurations in `activate`.

Closes #370