### PR TITLE
docs: fixup reference links

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,7 +26,7 @@ The following files are under *image_classification*
 | imagenet_classes.txt | The class labels for the outputs from alexnet | used by pytorch_classification.py |
 | prepare_aperturedb.py | Helper to download images from coco dataset, and load them into aperturedb | ``python prepare_aperturedb.py -images_count 100`` |
 | pytorch_classification.py | Pulls all images from aperturedb with a certain property set by prepare_aperturedb.py script , and classifies them using alexnet | ``python pytorch_classification.py`` |
-| pytorch_classification.ipynb | It does the same operation as ``pytorch_classification.py``. Also displays the classified images | Also available to read at [Aperturedb python documentation](https://docs.aperturedata.io/HowToGuides/Basic/pytorch_classification) |
+| pytorch_classification.ipynb | It does the same operation as ``pytorch_classification.py``. Also displays the classified images | Also available to read at [Aperturedb python documentation](https://docs.aperturedata.io/HowToGuides/Advanced/pytorch_classification) |
 
 ## Example 3: Similarity search using apertureDB
 
@@ -42,7 +42,7 @@ The following files are under *similarity_search*
 
 | File | Description | instructions |
 | -----| ------------| -----|
-| similarity_search.ipynb | A notebook with some sample code for describing similarity search using aperturedb | Also available to read at [Aperturedb documentation](https://docs.aperturedata.io/HowToGuides/Advanced/similarity_search)|
+| similarity_search.ipynb | A notebook with some sample code for describing similarity search using aperturedb | Also available to read at [Aperturedb documentation](https://docs.aperturedata.io/HowToGuides/Applications/similarity_search)|
 | facenet.py | Face Recognition using facenet and pytorch | Is invoked indirectly |
 | add_faces.py | A Script to load celebA dataset into aperturedb | ``python add_faces.py``|
 
@@ -62,4 +62,4 @@ The following files are under *loading_with_models*
 
 | File | Description | instructions |
 | -----| ------------| -----|
-| models.ipynb | A notebook with some sample code to add data using models | Also available to read at [Aperturedb model example](https://docs.aperturedata.io/HowToGuides/Advanced/models)|
+| models.ipynb | A notebook with some sample code to add data using models | Also available to read at [Aperturedb model example](https://docs.aperturedata.io/HowToGuides/Ingestion/DataModels)|

--- a/examples/loading_with_models/add_video_model.py
+++ b/examples/loading_with_models/add_video_model.py
@@ -54,7 +54,7 @@ client = create_connector()
 
 # Create a descriptor set
 # DS is a search space for descriptors added to it (some times called collections)
-# https://docs.aperturedata.io/HowToGuides/Advanced/similarity_search#descriptorsets-and-descriptors
+# https://docs.aperturedata.io/HowToGuides/Applications/similarity_search#descriptorsets-and-descriptors
 collection = DescriptorSetDataModel(
     name="marengo26", dimensions=len(clips[0]['embedding']))
 q, blobs, c = generate_add_query(collection)


### PR DESCRIPTION
## Summary

Updated reference links to match the new docs structure.

## Changes

- Fixed broken doc links in examples README and scripts

Fixes aperture-data/aperturedb-python#280