### PR TITLE
fix: Use a timeout value for requests.get (#410)

### DIFF
--- a/aperturedb/ImageDownloader.py
+++ b/aperturedb/ImageDownloader.py
@@ -107,9 +107,9 @@ class ImageDownloader(Parallelizer.Parallelizer):
         downloaded = False
         while True:
             try:
-                imgdata = requests.get(url)
+                imgdata = requests.get(url, timeout=10)
                 downloaded = True
-            except requests.exceptions.ConnectionError as e:
+            except requests.exceptions.RequestException as e:
                 logger.warning("Error with GET.")
                 logger.exception(e)
 

--- a/aperturedb/VideoDownloader.py
+++ b/aperturedb/VideoDownloader.py
@@ -96,7 +96,14 @@ class VideoDownloader(Parallelizer.Parallelizer):
         if not os.path.exists(folder):
             os.makedirs(folder, exist_ok=True)
 
-        videodata = requests.get(url)
+        try:
+            videodata = requests.get(url, timeout=10)
+        except requests.exceptions.RequestException as e:
+            print("Error with GET:", e)
+            self.error_counter += 1
+            self.times_arr.append(time.time() - start)
+            return
+
         if videodata.ok:
             fd = open(filename, "wb")
             fd.write(videodata.content)

--- a/test/test_SPARQL.py
+++ b/test/test_SPARQL.py
@@ -35,7 +35,7 @@ def load_cookbook(utils: Utils, db):
 
     try:
         # Download the script file
-        response = requests.get(file_url)
+        response = requests.get(file_url, timeout=10)
         file_path.write_text(response.text)
 
         runpy.run_path(str(file_path), run_name="__main__")


### PR DESCRIPTION
## Summary

Added a 10 seconds timeout for `requests.get` to prevent long waits for URL-based ingestions.

## Changes

- `aperturedb/ImageDownloader.py`: Added `timeout=10` and catch `RequestException`.
- `aperturedb/VideoDownloader.py`: Added `timeout=10` and catch `RequestException`.
- `test/test_SPARQL.py`: Added `timeout=10` for the external script download.

Fixes #410