### PR TITLE
fix: Redact tokens in query and response logs (#545)

### DIFF
--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -313,7 +313,25 @@ def execute_query(client: Connector, query: Commands,
                     raise e
     else:
         # Transaction failed entirely.
-        logger.error(f"Failed query = {query} with response = {r}")
+        import copy
+        safe_query = copy.deepcopy(query)
+        safe_r = copy.deepcopy(r)
+        for obj in (safe_query, safe_r):
+            if isinstance(obj, list):
+                for item in obj:
+                    if isinstance(item, dict) and "Authenticate" in item:
+                        auth_dict = item["Authenticate"]
+                        if isinstance(auth_dict, dict):
+                            if "password" in auth_dict:
+                                auth_dict["password"] = "***"
+                            if "token" in auth_dict:
+                                auth_dict["token"] = "***"
+                            if "session_token" in auth_dict:
+                                auth_dict["session_token"] = "***"
+                            if "refresh_token" in auth_dict:
+                                auth_dict["refresh_token"] = "***"
+
+        logger.error(f"Failed query = {safe_query} with response = {safe_r}")
         result = 1
 
     statuses = {}

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -639,8 +639,24 @@ class Connector(object):
         return self.clone()
 
     def get_last_response_str(self):
+        import copy
+        if not self.last_response:
+            return "[]"
 
-        return json.dumps(self.last_response, indent=4, sort_keys=False)
+        try:
+            safe_response = copy.deepcopy(self.last_response)
+            if isinstance(safe_response, list):
+                for item in safe_response:
+                    if isinstance(item, dict) and "Authenticate" in item:
+                        auth_dict = item["Authenticate"]
+                        if isinstance(auth_dict, dict):
+                            if "session_token" in auth_dict:
+                                auth_dict["session_token"] = "***"
+                            if "refresh_token" in auth_dict:
+                                auth_dict["refresh_token"] = "***"
+            return json.dumps(safe_response, indent=4, sort_keys=False)
+        except Exception:
+            return json.dumps(self.last_response, indent=4, sort_keys=False)
 
     def print_last_response(self):
 


### PR DESCRIPTION
## Summary

When an `Authenticate` query fails or a subsequent query fails and the last response was from authentication, the error logs were exposing `refresh_token`, `session_token`, and passwords. This change redacts them.

## Changes

- `aperturedb/Connector.py`: Modified `get_last_response_str` to deepcopy and scrub `session_token` and `refresh_token` inside `Authenticate`.
- `aperturedb/CommonLibrary.py`: Modified error logging in `execute_query` to also redact tokens/passwords in the query and response JSON before logging.

Fixes #545