### PR TITLE
fix: decouple use_dask from CSV parser

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,7 @@ jobs:
 
     - uses: actions/setup-python@v3
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - uses: pre-commit/action@v3.0.1
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
     - name: Cleanup previous run
-      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db*"
+      run: docker run --rm -v ${{ github.workspace }}:/workspace alpine sh -c "rm -rf /workspace/test/aperturedb/db* /workspace/test/aperturedb/logs*"
       continue-on-error: true
 
     - uses: actions/checkout@v3

--- a/aperturedb/BlobNewestDataCSV.py
+++ b/aperturedb/BlobNewestDataCSV.py
@@ -282,7 +282,9 @@ class BlobNewestDataCSV(CSVParser.CSVParser):
     def validate(self):
         self._setupkeys()
         valid = True
-        if not self.use_dask:
+        import dask.dataframe as dd
+        use_dask = hasattr(self, "df") and isinstance(self.df, dd.DataFrame)
+        if not use_dask:
             if len(self.constraints_keys) < 1:
                 logger.error("Cannot add/update " +
                              self.entity + "; no constraint keys")

--- a/aperturedb/CSVParser.py
+++ b/aperturedb/CSVParser.py
@@ -51,43 +51,19 @@ class CSVParser(Subscriptable):
         # The following are extracted from the kwargs.
         self.blobs_relative_to_csv = "blobs_relative_to_csv" in kwargs and kwargs[
             "blobs_relative_to_csv"]
-        self.use_dask = "use_dask" in kwargs and kwargs["use_dask"]
         df = kwargs["df"] if "df" in kwargs else None
 
         self.relative_path_prefix = os.path.dirname(self.filename) if self.blobs_relative_to_csv \
             else ""
 
-        if not self.use_dask:
-            if df is None:
-                self.df = pd.read_csv(filename)
-            else:
-                self.df = df
-
-            # we expect the df index to have 'start', which means RangeIndex.
-            # most users don't supply their own df, so this is mostly a sanity check
-            # for when an advanced user has done filtering and have a IntervalIndex.
-            if not isinstance(self.df.index, pd.RangeIndex):
-                raise TypeError(
-                    f"CSVParser requires a RangeIndex. the supplied DataFrame has a {type(self.df.index)} index.")
+        if df is None:
+            self.df = pd.read_csv(filename)
         else:
-            if df is not None:
-                raise ValueError(
-                    "Dask mode requires a CSV filename; DataFrame inputs are not supported.")
-            # It'll impact the number of partitions, and memory usage.
-            # TODO: tune this for the best performance.
-            cores_used = int(CORES_USED_FOR_PARALLELIZATION * mp.cpu_count())
-            blocksize = os.path.getsize(
-                self.filename) // (cores_used * PARTITIONS_PER_CORE)
-            if blocksize == 0:
-                cpus = mp.cpu_count()
-                raise Exception(
-                    f"CSV file too small to be read in parallel. Use normal mode. cpus: {cpus}")
-            self.df = dataframe.read_csv(
-                self.filename,
-                blocksize=blocksize)
+            self.df = df
 
+        import dask.dataframe as dd
         # len for dask dataframe needs a client.
-        if not self.use_dask and len(self.df) == 0:
+        if not isinstance(self.df, dd.DataFrame) and len(self.df) == 0:
             logger.error("Dataframe empty. Is the CSV file ok?")
 
         self.df = self.df.astype('object')

--- a/aperturedb/CSVWriter.py
+++ b/aperturedb/CSVWriter.py
@@ -30,7 +30,9 @@ def convert_entity_data(input, entity_class: str, unique_key: Optional[str] = No
     df = pd.DataFrame(input)
     df.insert(0, 'EntityClass', entity_class)
     if unique_key:
-        assert unique_key in df.columns, f"unique_key {unique_key} not found in the input data"
+        assert unique_key in df.columns, (
+            f"unique_key {unique_key} not found in the input data"
+        )
         df[f"constraint_{unique_key}"] = df[unique_key]
     return df
 
@@ -66,7 +68,9 @@ def convert_image_data(input, source_column: str, source_type: Optional[str] = N
     """
     df = pd.DataFrame(input)
 
-    assert source_column in df.columns, f"source_column {source_column} not found in the input data"
+    assert source_column in df.columns, (
+        f"source_column {source_column} not found in the input data"
+    )
 
     if source_type is None:
         source_type = source_column
@@ -82,7 +86,9 @@ def convert_image_data(input, source_column: str, source_type: Optional[str] = N
         df.insert(0, source_type, df[source_column])
 
     if unique_key is not None:
-        assert unique_key in df.columns, f"unique_key {unique_key} not found in the input data"
+        assert unique_key in df.columns, (
+            f"unique_key {unique_key} not found in the input data"
+        )
         df[f"constraint_{unique_key}"] = df[unique_key]
 
     if format is not None:
@@ -140,11 +146,15 @@ def convert_connection_data(input,
 
     if source_column is None:
         source_column = source_property
-    assert source_column in df.columns, f"source_column {source_column} not found in the input data"
+    assert source_column in df.columns, (
+        f"source_column {source_column} not found in the input data"
+    )
 
     if destination_column is None:
         destination_column = destination_property
-    assert destination_column in df.columns, f"destination_column {destination_column} not found in the input data"
+    assert destination_column in df.columns, (
+        f"destination_column {destination_column} not found in the input data"
+    )
 
     df.insert(0, 'ConnectionClass', connection_class)
     df.insert(1, f"{source_class}@{source_property}", df[source_column])
@@ -152,7 +162,9 @@ def convert_connection_data(input,
               df[destination_column])
 
     if unique_key:
-        assert unique_key in df.columns, f"unique_key {unique_key} not found in the input data"
+        assert unique_key in df.columns, (
+            f"unique_key {unique_key} not found in the input data"
+        )
         df[f"constraint_{unique_key}"] = df[unique_key]
 
     return df

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -83,9 +83,15 @@ def _create_configuration_from_json(config: Union[Dict, str],
     clean_config = {k: v for k, v in config.items() if k != "password"}
 
     # These fields are required.
-    assert "host" in config, f"host is required in the configuration: {clean_config}"
-    assert "username" in config, f"username is required in the configuration: {clean_config}"
-    assert "password" in config, f"password is required in the configuration: {clean_config}"
+    assert "host" in config, (
+        f"host is required in the configuration: {clean_config}"
+    )
+    assert "username" in config, (
+        f"username is required in the configuration: {clean_config}"
+    )
+    assert "password" in config, (
+        f"password is required in the configuration: {clean_config}"
+    )
 
     # These fields have no default in the Configuration class.
     if 'port' not in config:
@@ -95,7 +101,9 @@ def _create_configuration_from_json(config: Union[Dict, str],
         config["name"] = name  # will overwrite the name in the config
 
     if name_required:
-        assert "name" in config, f"name is required in the configuration: {clean_config}"
+        assert "name" in config, (
+            f"name is required in the configuration: {clean_config}"
+        )
     elif 'name' not in config:
         config["name"] = "from_json"
 

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -23,7 +23,7 @@ def import_module_by_path(filepath: str) -> Any:
     """
     This function imports a module given a path to a python file.
     """
-    module_name = os.path.basename(filepath)[:-3]
+    module_name = os.path.splitext(os.path.basename(filepath))[0]
     spec = importlib.util.spec_from_file_location(module_name, filepath)
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -422,8 +422,7 @@ class Connector(object):
 
         except FileNotFoundError as e:
             logger.exception(
-                f"The certificate file does not exist: {self.config.ca_cert}")
-            logger.exception(
+                f"The certificate file does not exist: {self.config.ca_cert}\n"
                 f"You can use the ca_cert parameter to specify a custom CA certificate")
             assert False, "Certificate verification failed" + os.linesep + \
                 f"The ca certificate file does not exist: {self.config.ca_cert} " + os.linesep + \
@@ -500,24 +499,24 @@ class Connector(object):
                 if tries != 0 or (self.last_query_timestamp is not None and
                                   (now - self.last_query_timestamp) <
                                   self.query_connection_error_suppression_delta):
-                    logger.exception(ssle)
                     logger.warning(
-                        f"SSL connection error on process {os.getpid()}")
+                        f"SSL connection error on process {os.getpid()}",
+                        exc_info=True)
             except ssl.SSLError as ssle:
                 # This can happen in a scenario where multiple
                 # processes might be accessing a single connection.
                 # The copy does not make usable connections.
-                logger.exception(ssle)
-                logger.warning(f"SSL error on process {os.getpid()}")
+                logger.warning(
+                    f"SSL error on process {os.getpid()}", exc_info=True)
             except OSError as ose:
-                logger.exception(ose)
-                logger.warning(f"OS error on process {os.getpid()}")
+                logger.warning(
+                    f"OS error on process {os.getpid()}", exc_info=True)
             except AttributeError as ae:
                 if self.connected:
                     # Only log if we got this while connected.
                     # else it is expected after unification of query/connect
-                    logger.exception(ae)
-                    logger.warning(f"Attribute error on process {os.getpid()}")
+                    logger.warning(
+                        f"Attribute error on process {os.getpid()}", exc_info=True)
 
             tries += 1
             # Do not log when trying for the first time.

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -153,7 +153,8 @@ class Connector(object):
                  retry_interval_seconds=DEFAULT_RETRY_INTERVAL_SECONDS,
                  retry_max_attempts=DEFAULT_RETRY_MAX_ATTEMPTS,
                  config: Optional[Configuration] = None,
-                 key: Optional[str] = None):
+                 key: Optional[str] = None,
+                 connect: bool = False):
         """
         Constructor for the Connector class.
         """
@@ -209,6 +210,9 @@ class Connector(object):
         # One time flag to indicate if we ever connected,
         # to prevent logging of connection errors on first connect.
         self._ever_connected = False
+
+        if connect:
+            self.connect()
 
     def authenticate(self, shared_data, user, password, token):
         """

--- a/aperturedb/EntityDataCSV.py
+++ b/aperturedb/EntityDataCSV.py
@@ -116,10 +116,12 @@ class EntityDeleteDataCSV(CSVParser.CSVParser):
 
     """
 
-    def __init__(self, entity_class, filename, df=None, use_dask=False):
-        super().__init__(filename, df=df, use_dask=use_dask)
+    def __init__(self, entity_class, filename, df=None):
+        super().__init__(filename, df=df)
         self.command = "Delete" + entity_class
         self.constraint_keyword = "constraints"
+        import dask.dataframe as dd
+        use_dask = hasattr(self, "df") and isinstance(self.df, dd.DataFrame)
         if not use_dask:
             self.constraint_keys = [x for x in self.header[0:]]
 
@@ -143,5 +145,5 @@ class ImageDeleteDataCSV(EntityDeleteDataCSV):
     Usage details in EntityDeleteDataCSV
     """
 
-    def __init__(self, filename, df=None, use_dask=False):
-        super().__init__("Image", filename, df=df, use_dask=use_dask)
+    def __init__(self, filename, df=None):
+        super().__init__("Image", filename, df=df)

--- a/aperturedb/EntityUpdateDataCSV.py
+++ b/aperturedb/EntityUpdateDataCSV.py
@@ -130,7 +130,9 @@ class SingleEntityUpdateDataCSV(CSVParser.CSVParser):
     def validate(self):
         self._setupkeys()
         valid = True
-        if not self.use_dask:
+        import dask.dataframe as dd
+        use_dask = hasattr(self, "df") and isinstance(self.df, dd.DataFrame)
+        if not use_dask:
             if len(self.constraints_keys) < 1:
                 logger.error("Cannot add/update " +
                              self.entity + "; no constraint keys")
@@ -143,8 +145,8 @@ class SingleEntityUpdateDataCSV(CSVParser.CSVParser):
 
 
 class EntityUpdatDataCSV(SingleEntityUpdateDataCSV):
-    def __init__(self, entity_type, filename, df=None, use_dask=False):
-        super().__init__("Entity", filename, df, use_dask)
+    def __init__(self, entity_type, filename, df=None):
+        super().__init__("Entity", filename, df)
         self.entity_type = entity_type
         # Add had blob and update has blob.
         self.blobs_per_query = [0, 0]

--- a/aperturedb/ImageDataCSV.py
+++ b/aperturedb/ImageDataCSV.py
@@ -35,8 +35,10 @@ class ImageDataProcessor():
         self.check_image = check_image
         self.n_download_retries = n_download_retries
 
-    def set_processor(self, use_dask: bool, source_type):
+    def set_processor(self, source_type):
         self.source_type = source_type
+        import dask.dataframe as dd
+        use_dask = isinstance(self.df, dd.DataFrame)
         if use_dask == False and self.source_type == HEADER_S3_URL:
             # The connections by boto3 cause ResourceWarning. Known
             # issue: https://github.com/boto/boto3/issues/454
@@ -180,7 +182,7 @@ class ImageDataCSV(CSVParser.CSVParser, ImageDataProcessor):
         CSVParser.CSVParser.__init__(self, filename, **kwargs)
 
         source_type = self.header[0]
-        self.set_processor(self.use_dask, source_type)
+        self.set_processor(source_type)
 
         self.format_given = IMG_FORMAT in self.header
         self.props_keys = [x for x in self.header[1:]
@@ -264,7 +266,7 @@ class ImageUpdateDataCSV(SingleEntityUpdateDataCSV, ImageDataProcessor):
             self, "Image", filename, **kwargs)
 
         source_type = self.header[0]
-        self.set_processor(self.use_dask, source_type)
+        self.set_processor(source_type)
 
         # this class loads a blob, so must set the first query to have a blob.
         self.blobs_per_query = [1, 0]
@@ -317,7 +319,7 @@ class ImageForceNewestDataCSV(BlobNewestDataCSV, ImageDataProcessor):
             self, "Image", filename, **kwargs)
 
         source_type = self.header[0]
-        self.set_processor(self.use_dask, source_type)
+        self.set_processor(source_type)
 
         self.format_given = IMG_FORMAT in self.header
         self.props_keys = list(filter(lambda prop: prop not in [
@@ -372,7 +374,7 @@ class ImageSparseAddDataCSV(SparseAddingDataCSV, ImageDataProcessor):
             self, check_image, n_download_retries)
         SparseAddingDataCSV.__init__(self, "Image", filename, **kwargs)
         source_type = self.header[0]
-        self.set_processor(self.use_dask, source_type)
+        self.set_processor(source_type)
 
         self.format_given = IMG_FORMAT in self.header
         self.props_keys = list(filter(lambda prop: prop not in [

--- a/aperturedb/ParallelLoader.py
+++ b/aperturedb/ParallelLoader.py
@@ -26,8 +26,8 @@ class ParallelLoader(ParallelQuery.ParallelQuery):
     into batches, and passing the batches to multiple workers.
     """
 
-    def __init__(self, client: Connector, dry_run: bool = False):
-        super().__init__(client, dry_run=dry_run)
+    def __init__(self, client: Connector, dry_run: bool = False, use_dask: bool = False):
+        super().__init__(client, dry_run=dry_run, use_dask=use_dask)
         self.utils = Utils(self.client)
         self.type = "element"
 

--- a/aperturedb/ParallelLoader.py
+++ b/aperturedb/ParallelLoader.py
@@ -204,9 +204,9 @@ class ParallelLoader(ParallelQuery.ParallelQuery):
             print(f"Query time std: {std}")
             print(f"Avg Query Throughput (q/s): {tp}")
 
-            i_tp = self.total_actions / self.total_actions_time
+            i_tp = succeeded_queries / self.total_actions_time if self.total_actions_time > 0 else 0
             print(
-                f"Overall insertion throughput ({self.type}/s): {i_tp if self.error_counter == 0 else 'NaN'}")
+                f"Overall insertion throughput ({self.type}/s): {i_tp}")
 
             if self.error_counter > 0:
                 err_perc = 100 * self.error_counter / total_queries_exec

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -37,8 +37,8 @@ class ParallelQuery(Parallelizer.Parallelizer):
     def getSuccessStatus(cls):
         return cls.success_statuses
 
-    def __init__(self, client: Connector, dry_run: bool = False):
-        super().__init__()
+    def __init__(self, client: Connector, dry_run: bool = False, use_dask: bool = False):
+        super().__init__(use_dask=use_dask)
         test_string = f"Connection test successful with {client.config}"
         try:
             _, _ = client.query([{"GetSchema": {}}], [])
@@ -270,7 +270,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
             stats (bool, optional): Show statistics at end of ingestion. Defaults to False.
         """
 
-        use_dask = hasattr(generator, "use_dask") and generator.use_dask
+        use_dask = hasattr(self, "use_dask") and self.use_dask
         if use_dask:
             self._reset(batchsize=batchsize, numthreads=numthreads)
             self.daskmanager = DaskManager(num_workers=numthreads)

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -209,6 +209,9 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 worker_stats["succeeded_queries"] = sq
         else:
             query_time = 1
+            worker_stats["succeeded_commands"] = len(q)
+            worker_stats["succeeded_queries"] = len(data)
+            worker_stats["objects_existed"] = 0
 
         # append is thread-safe
         self.times_arr.append(query_time)
@@ -334,9 +337,10 @@ class ParallelQuery(Parallelizer.Parallelizer):
             print(f"Query time std: {std}")
             print(f"Avg Query Throughput (q/s): {tp}")
 
-            i_tp = self.total_actions / self.total_actions_time
+            i_tp = self.get_succeeded_queries(
+            ) / self.total_actions_time if self.total_actions_time > 0 else 0
             print(
-                f"Overall insertion throughput ({self.type}/s): {i_tp if self.error_counter == 0 else 'NaN'}")
+                f"Overall insertion throughput ({self.type}/s): {i_tp}")
 
             if self.error_counter > 0:
                 err_perc = 100 * self.error_counter / total_queries_exec

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -308,7 +308,8 @@ class ParallelQuery(Parallelizer.Parallelizer):
                         f"Could not determine query structure from:\n{generator[0]}")
                     logger.error(type(generator[0]))
             logger.info(
-                f"Commands per query = {self.commands_per_query}, Blobs per query = {self.blobs_per_query}"
+                f"Commands per query = {self.commands_per_query}, "
+                f"Blobs per query = {self.blobs_per_query}"
             )
             self.batched_run(generator, batchsize, numthreads, stats)
 

--- a/aperturedb/ParallelQuerySet.py
+++ b/aperturedb/ParallelQuerySet.py
@@ -152,11 +152,13 @@ def gen_execute_batch_sets(base_executor):
             blobs_this_set = len(blob_filter(blob_set, [], i))
             expected_blobs = blobs_per_query[i] * batch_size
             logger.info(
-                f"Set {i}: Commands per query = {commands_per_query[i]}, Blobs per query = {blobs_per_query[i]}"
+                f"Set {i}: Commands per query = {commands_per_query[i]}, "
+                f"Blobs per query = {blobs_per_query[i]}"
             )
             if blobs_this_set != expected_blobs:
                 logger.error(
-                    f"Set {i}: Expected {expected_blobs} blobs, but filter is returning {blobs_this_set}"
+                    f"Set {i}: Expected {expected_blobs} blobs, "
+                    f"but filter is returning {blobs_this_set}"
                 )
 
             # now we determine if the executing set has a constraint

--- a/aperturedb/ParallelQuerySet.py
+++ b/aperturedb/ParallelQuerySet.py
@@ -418,9 +418,10 @@ class ParallelQuerySet(ParallelQuery):
             print(f"Query time std: {std}")
             print(f"Avg Query Throughput (q/s): {tp}")
 
-            i_tp = self.total_actions / self.total_actions_time
+            i_tp = self.get_succeeded_queries(
+            ) / self.total_actions_time if self.total_actions_time > 0 else 0
             print(
-                f"Overall insertion throughput ({self.type}/s): {i_tp if self.error_counter == 0 else 'NaN'}")
+                f"Overall insertion throughput ({self.type}/s): {i_tp}")
 
             if self.error_counter > 0:
                 err_perc = 100 * self.error_counter / total_queries_exec

--- a/aperturedb/Parallelizer.py
+++ b/aperturedb/Parallelizer.py
@@ -28,7 +28,8 @@ class Parallelizer:
     ```
     """
 
-    def __init__(self):
+    def __init__(self, use_dask: bool = False):
+        self.use_dask = use_dask
         self._reset()
 
     def _reset(self, batchsize: int = 1, numthreads: int = 1):

--- a/aperturedb/Query.py
+++ b/aperturedb/Query.py
@@ -87,8 +87,10 @@ def get_specific(obj: BaseModel) -> dict:
         start, stop  = obj.start, obj.stop
         if obj.range_type == RangeType.TIME:
             start, stop = int(start), int(stop)
-            start = f"{start//3600:0>2}:{start//60:0>2}:{start%60:0>2}"
-            stop = f"{stop//3600:0>2}:{stop//60:0>2}:{stop%60:0>2}"
+            start = "{:0>2}:{:0>2}:{:0>2}".format(
+                start // 3600, (start // 60) % 60, start % 60)
+            stop = "{:0>2}:{:0>2}:{:0>2}".format(
+                stop // 3600, (stop // 60) % 60, stop % 60)
         elif obj.range_type == RangeType.FRAME:
             start = int(obj.start)
             stop = int(obj.stop)

--- a/aperturedb/SparseAddingDataCSV.py
+++ b/aperturedb/SparseAddingDataCSV.py
@@ -61,7 +61,9 @@ class SparseAddingDataCSV(CSVParser.CSVParser):
     def validate(self):
         self._setupkeys()
         valid = True
-        if not self.use_dask:
+        import dask.dataframe as dd
+        use_dask = hasattr(self, "df") and isinstance(self.df, dd.DataFrame)
+        if not use_dask:
             if len(self.constraints_keys) < 1:
                 logger.error("Cannot add/update " +
                              self.entity + "; no constraint keys")

--- a/aperturedb/Utils.py
+++ b/aperturedb/Utils.py
@@ -182,7 +182,17 @@ class Utils(object):
             <TR><TD BGCOLOR="{colors["entity_background"]}" COLSPAN="3"><FONT COLOR="{colors["entity_foreground"]}"><B>{entity}</B> ({matched:,})</FONT></TD></TR>
             '''
             for prop, (matched, indexed, typ) in properties.items():
-                table += f'<TR><TD BGCOLOR="{colors["property_background"]}"><FONT COLOR="{colors["property_foreground"]}"><B>{prop.strip()}</B></FONT></TD> <TD BGCOLOR="{colors["property_background"]}"><FONT COLOR="{colors["property_foreground"]}">{matched:,}</FONT></TD> <TD BGCOLOR="{colors["property_background"]}"><FONT COLOR="{colors["property_foreground"]}">{"Indexed" if indexed else "Unindexed"}, {typ}</FONT></TD></TR>'
+                bg = colors["property_background"]
+                fg = colors["property_foreground"]
+                idx_str = "Indexed" if indexed else "Unindexed"
+                table += (
+                    f'<TR><TD BGCOLOR="{bg}"><FONT COLOR="{fg}">'
+                    f'<B>{prop.strip()}</B></FONT></TD> '
+                    f'<TD BGCOLOR="{bg}"><FONT COLOR="{fg}">'
+                    f'{matched:,}</FONT></TD> '
+                    f'<TD BGCOLOR="{bg}"><FONT COLOR="{fg}">'
+                    f'{idx_str}, {typ}</FONT></TD></TR>'
+                )
             for connection, data in connections.items():
                 data_list = [data] if isinstance(data, dict) else data
                 for data in data_list:
@@ -190,10 +200,26 @@ class Utils(object):
                         matched = data["matched"]
                         # dictionary from name to (matched, indexed, type)
                         properties = data["properties"]
-                        table += f'<TR><TD BGCOLOR="{colors["connection_background"]}" COLSPAN="3" PORT="{connection}"><FONT COLOR="{colors["connection_foreground"]}"><B>{connection}</B> ({matched:,})</FONT></TD></TR>'
+                        c_bg = colors["connection_background"]
+                        c_fg = colors["connection_foreground"]
+                        table += (
+                            '<TR><TD BGCOLOR="{}" COLSPAN="3" '
+                            'PORT="{}"><FONT COLOR="{}">'
+                            '<B>{}</B> ({:,})</FONT></TD></TR>'
+                        ).format(c_bg, connection, c_fg, connection, matched)
                         if properties:
                             for prop, (matched, indexed, typ) in properties.items():
-                                table += f'<TR><TD BGCOLOR="{colors["connection_property_background"]}"><FONT COLOR="{colors["connection_property_foreground"]}"><B>{prop.strip()}</B></FONT></TD> <TD BGCOLOR="{colors["connection_property_background"]}"><FONT COLOR="{colors["connection_property_foreground"]}">{matched:,}</FONT></TD> <TD BGCOLOR="{colors["connection_property_background"]}"><FONT COLOR="{colors["connection_property_foreground"]}">{"Indexed" if indexed else "Unindexed"}, {typ}</FONT></TD></TR>'
+                                cp_bg = colors["connection_property_background"]
+                                cp_fg = colors["connection_property_foreground"]
+                                idx_str = "Indexed" if indexed else "Unindexed"
+                                table += (
+                                    '<TR><TD BGCOLOR="{}"><FONT COLOR="{}">'
+                                    '<B>{}</B></FONT></TD> '
+                                    '<TD BGCOLOR="{}"><FONT COLOR="{}">'
+                                    '{}</FONT></TD> '
+                                    '<TD BGCOLOR="{}"><FONT COLOR="{}">'
+                                    '{}, {}</FONT></TD></TR>'
+                                ).format(cp_bg, cp_fg, prop.strip(), cp_bg, cp_fg, f"{matched:,}", cp_bg, cp_fg, idx_str, typ)
 
             table += '</TABLE>>'
             dot.node(entity, label=table)
@@ -243,7 +269,7 @@ class Utils(object):
             w = "!" if "id" in k and not p[k][1] else w
             print(f"{i} {w} {p[k][2].ljust(8)} |"
                   f" {k.ljust(max)} | {str(p[k][0]).rjust(9)} "
-                  f"({int(p[k][0]/total_elements*100.0)}%)")
+                  f"({int(p[k][0] / total_elements * 100.0)}%)")
 
         return total_elements
 

--- a/aperturedb/VideoDataCSV.py
+++ b/aperturedb/VideoDataCSV.py
@@ -89,7 +89,9 @@ class VideoDataCSV(CSVParser.CSVParser):
             HEADER_GS_URL: self.load_gs_url
         }
         self.source_type = self.header[0]
-        if self.use_dask == False and self.source_type == HEADER_S3_URL:
+        import dask.dataframe as dd
+        use_dask = hasattr(self, "df") and isinstance(self.df, dd.DataFrame)
+        if use_dask == False and self.source_type == HEADER_S3_URL:
             s3_client = boto3.client('s3')
             self.sources = Sources(3, s3_client=s3_client)
         else:

--- a/aperturedb/cli/configure.py
+++ b/aperturedb/cli/configure.py
@@ -193,7 +193,8 @@ def create(
     def check_for_overwrite(name):
         if name in configs and not overwrite:
             console.log(
-                f"Configuration named '{name}' already exists. Use --overwrite to overwrite.",
+                "Configuration named '{}' already exists. Use --overwrite to overwrite.".format(
+                    name),
                 style="bold yellow")
             raise typer.Exit(code=2)
 

--- a/aperturedb/cli/ingest.py
+++ b/aperturedb/cli/ingest.py
@@ -223,15 +223,19 @@ def from_csv(filepath: Annotated[str, typer.Argument(
         CORES_USED_FOR_PARALLELIZATION = 0.9
         PARTITIONS_PER_CORE = 10
         cores_used = int(CORES_USED_FOR_PARALLELIZATION * mp.cpu_count())
-        blocksize = os.path.getsize(filepath) // (cores_used * PARTITIONS_PER_CORE)
+        blocksize = os.path.getsize(
+            filepath) // (cores_used * PARTITIONS_PER_CORE)
         if blocksize == 0:
             cpus = mp.cpu_count()
-            raise Exception(f"CSV file too small to be read in parallel. Use normal mode. cpus: {cpus}")
+            raise Exception(
+                f"CSV file too small to be read in parallel. Use normal mode. cpus: {cpus}")
         df = dd.read_csv(filepath, blocksize=blocksize)
-        data = ingest_types[ingest_type](filepath, df=df, blobs_relative_to_csv=blobs_relative_to_csv)
+        data = ingest_types[ingest_type](
+            filepath, df=df, blobs_relative_to_csv=blobs_relative_to_csv)
     else:
-        data = ingest_types[ingest_type](filepath, blobs_relative_to_csv=blobs_relative_to_csv)
-    
+        data = ingest_types[ingest_type](
+            filepath, blobs_relative_to_csv=blobs_relative_to_csv)
+
     data.sample_count = len(data) if sample_count == -1 else sample_count
     if transformer or user_transformer:
         transformer = transformer or []

--- a/aperturedb/cli/ingest.py
+++ b/aperturedb/cli/ingest.py
@@ -220,15 +220,17 @@ def from_csv(filepath: Annotated[str, typer.Argument(
     import multiprocessing as mp
     if use_dask:
         import dask.dataframe as dd
-        CORES_USED_FOR_PARALLELIZATION = 0.9
-        PARTITIONS_PER_CORE = 10
+        from aperturedb.CSVParser import CORES_USED_FOR_PARALLELIZATION
+        from aperturedb.CSVParser import PARTITIONS_PER_CORE
         cores_used = int(CORES_USED_FOR_PARALLELIZATION * mp.cpu_count())
         blocksize = os.path.getsize(
             filepath) // (cores_used * PARTITIONS_PER_CORE)
         if blocksize == 0:
             cpus = mp.cpu_count()
-            raise Exception(
+            import typer
+            console.log(
                 f"CSV file too small to be read in parallel. Use normal mode. cpus: {cpus}")
+            raise typer.Abort()
         df = dd.read_csv(filepath, blocksize=blocksize)
         data = ingest_types[ingest_type](
             filepath, df=df, blobs_relative_to_csv=blobs_relative_to_csv)

--- a/aperturedb/cli/ingest.py
+++ b/aperturedb/cli/ingest.py
@@ -90,7 +90,7 @@ def _create_pipeline(transformers: List[str]):
     return pipeline
 
 
-def _process_data(data, sample_count, module_name, batchsize, num_workers, stats, debug):
+def _process_data(data, sample_count, module_name, batchsize, num_workers, stats, debug, use_dask=False):
     if debug:
         _debug_samples(data, sample_count, module_name)
     else:
@@ -98,7 +98,7 @@ def _process_data(data, sample_count, module_name, batchsize, num_workers, stats
         from aperturedb.CommonLibrary import create_connector
 
         client = create_connector()
-        loader = ParallelLoader(client)
+        loader = ParallelLoader(client, use_dask=use_dask)
         loader.ingest(
             data,
             stats=stats,
@@ -157,7 +157,8 @@ def from_generator(filepath: Annotated[str, typer.Argument(
         batchsize=batchsize,
         num_workers=num_workers,
         stats=stats,
-        debug=debug
+        debug=debug,
+        use_dask=False
     )
 
     while hasattr(data, "ncalls"):
@@ -215,8 +216,22 @@ def from_csv(filepath: Annotated[str, typer.Argument(
         IngestType.VIDEO: VideoDataCSV
     }
 
-    data = ingest_types[ingest_type](filepath, use_dask=use_dask,
-                                     blobs_relative_to_csv=blobs_relative_to_csv)
+    import os
+    import multiprocessing as mp
+    if use_dask:
+        import dask.dataframe as dd
+        CORES_USED_FOR_PARALLELIZATION = 0.9
+        PARTITIONS_PER_CORE = 10
+        cores_used = int(CORES_USED_FOR_PARALLELIZATION * mp.cpu_count())
+        blocksize = os.path.getsize(filepath) // (cores_used * PARTITIONS_PER_CORE)
+        if blocksize == 0:
+            cpus = mp.cpu_count()
+            raise Exception(f"CSV file too small to be read in parallel. Use normal mode. cpus: {cpus}")
+        df = dd.read_csv(filepath, blocksize=blocksize)
+        data = ingest_types[ingest_type](filepath, df=df, blobs_relative_to_csv=blobs_relative_to_csv)
+    else:
+        data = ingest_types[ingest_type](filepath, blobs_relative_to_csv=blobs_relative_to_csv)
+    
     data.sample_count = len(data) if sample_count == -1 else sample_count
     if transformer or user_transformer:
         transformer = transformer or []
@@ -228,11 +243,12 @@ def from_csv(filepath: Annotated[str, typer.Argument(
     _process_data(
         data,
         sample_count=sample_count,
-        module_name=os.path.basename(filepath),
+        module_name=os.path.basename(filepath)[:-4],
         batchsize=batchsize,
         num_workers=num_workers,
         stats=stats,
-        debug=debug
+        debug=debug,
+        use_dask=use_dask
     )
 
 

--- a/examples/CelebADataKaggle.py
+++ b/examples/CelebADataKaggle.py
@@ -62,7 +62,13 @@ class CelebADataKaggle(KaggleData):
                 }
             }
         ]
-        q[0]["AddImage"]["properties"]["keypoints"] = f"10 {p['lefteye_x']} {p['lefteye_y']} {p['righteye_x']} {p['righteye_y']} {p['nose_x']} {p['nose_y']} {p['leftmouth_x']} {p['leftmouth_y']} {p['rightmouth_x']} {p['rightmouth_y']}"
+        q[0]["AddImage"]["properties"]["keypoints"] = (
+            f"10 {p['lefteye_x']} {p['lefteye_y']} "
+            f"{p['righteye_x']} {p['righteye_y']} "
+            f"{p['nose_x']} {p['nose_y']} "
+            f"{p['leftmouth_x']} {p['leftmouth_y']} "
+            f"{p['rightmouth_x']} {p['rightmouth_y']}"
+        )
 
         image_file_name = os.path.join(
             self.workdir,

--- a/examples/CelebADataKaggle.py
+++ b/examples/CelebADataKaggle.py
@@ -15,7 +15,7 @@ class CelebADataKaggle(KaggleData):
 
     def __init__(self, **kwargs) -> None:
         self.records_count = -1
-        super().__init__(dataset_ref = "jessicali9530/celeba-dataset",
+        super().__init__(dataset_ref="jessicali9530/celeba-dataset",
                          records_count=self.records_count)
 
     def generate_index(self, root: str, records_count=-1) -> pd.DataFrame:

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,7 +26,7 @@ The following files are under *image_classification*
 | imagenet_classes.txt | The class labels for the outputs from alexnet | used by pytorch_classification.py |
 | prepare_aperturedb.py | Helper to download images from coco dataset, and load them into aperturedb | ``python prepare_aperturedb.py -images_count 100`` |
 | pytorch_classification.py | Pulls all images from aperturedb with a certain property set by prepare_aperturedb.py script , and classifies them using alexnet | ``python pytorch_classification.py`` |
-| pytorch_classification.ipynb | It does the same operation as ``pytorch_classification.py``. Also displays the classified images | Also available to read at [Aperturedb python documentation](https://docs.aperturedata.io/HowToGuides/Basic/pytorch_classification) |
+| pytorch_classification.ipynb | It does the same operation as ``pytorch_classification.py``. Also displays the classified images | Also available to read at [Aperturedb python documentation](https://docs.aperturedata.io/HowToGuides/Advanced/pytorch_classification) |
 
 ## Example 3: Similarity search using apertureDB
 
@@ -42,7 +42,7 @@ The following files are under *similarity_search*
 
 | File | Description | instructions |
 | -----| ------------| -----|
-| similarity_search.ipynb | A notebook with some sample code for describing similarity search using aperturedb | Also available to read at [Aperturedb documentation](https://docs.aperturedata.io/HowToGuides/Advanced/similarity_search)|
+| similarity_search.ipynb | A notebook with some sample code for describing similarity search using aperturedb | Also available to read at [Aperturedb documentation](https://docs.aperturedata.io/HowToGuides/Applications/similarity_search)|
 | facenet.py | Face Recognition using facenet and pytorch | Is invoked indirectly |
 | add_faces.py | A Script to load celebA dataset into aperturedb | ``python add_faces.py``|
 
@@ -62,4 +62,4 @@ The following files are under *loading_with_models*
 
 | File | Description | instructions |
 | -----| ------------| -----|
-| models.ipynb | A notebook with some sample code to add data using models | Also available to read at [Aperturedb model example](https://docs.aperturedata.io/HowToGuides/Advanced/models)|
+| models.ipynb | A notebook with some sample code to add data using models | Also available to read at [Aperturedb model example](https://docs.aperturedata.io/HowToGuides/Ingestion/DataModels)|

--- a/examples/loading_with_models/add_video_model.py
+++ b/examples/loading_with_models/add_video_model.py
@@ -54,7 +54,7 @@ client = create_connector()
 
 # Create a descriptor set
 # DS is a search space for descriptors added to it (some times called collections)
-# https://docs.aperturedata.io/HowToGuides/Advanced/similarity_search#descriptorsets-and-descriptors
+# https://docs.aperturedata.io/HowToGuides/Applications/similarity_search#descriptorsets-and-descriptors
 collection = DescriptorSetDataModel(
     name="marengo26", dimensions=len(clips[0]['embedding']))
 q, blobs, c = generate_add_query(collection)

--- a/examples/loading_with_models/get_tl_embeddings.py
+++ b/examples/loading_with_models/get_tl_embeddings.py
@@ -59,7 +59,7 @@ embeddings, task_result = generate_embedding(video_url)
 
 print(f"Generated {len(embeddings)} embeddings for the video")
 for i, emb in enumerate(embeddings):
-    print(f"Embedding {i+1}:")
+    print(f"Embedding {i + 1}:")
     print(f"  Scope: {emb['embedding_scope']}")
     print(
         f"  Time range: {emb['start_offset_sec']} - {emb['end_offset_sec']} seconds")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -145,7 +145,10 @@ def insert_data_from_csv(db, request):
             for tp, classes in expected_indices.items():
                 for cls, props in classes.items():
                     for prop in props:
-                        err_msg = f"Index {prop} not found for {cls}, {expected_indices=}, {observed_indices=}"
+                        err_msg = (
+                            f"Index {prop} not found for {cls}, "
+                            f"{expected_indices=}, {observed_indices=}"
+                        )
                         assert prop in observed_indices[tp][cls], err_msg
         assert loader.error_counter == 0
         assert len(data) - \

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -25,7 +25,7 @@ services:
         condition: service_started
     image: $LENZ_REPO:$LENZ_TAG
     ports:
-      - $GATEWAY:55556:55551
+      - "$GATEWAY:0:55551"
     restart: always
     environment:
       LNZ_HEALTH_PORT: 58085
@@ -65,8 +65,8 @@ services:
     image: nginx
     restart: always
     ports:
-      - $GATEWAY:8087:80
-      - $GATEWAY:8443:443
+      - "$GATEWAY:0:80"
+      - "$GATEWAY:0:443"
     configs:
       - source: nginx.conf
         target: /etc/nginx/conf.d/default.conf

--- a/test/run_test_container.sh
+++ b/test/run_test_container.sh
@@ -25,7 +25,12 @@ function run_aperturedb_instance(){
     docker network create ${TAG}_host_default
     GATEWAY=$(docker network inspect ${TAG}_host_default | jq -r .[0].IPAM.Config[0].Gateway)
     GATEWAY=$GATEWAY RUNNER_NAME=$TAG docker compose -f docker-compose.yml up -d
-    echo "$GATEWAY"
+    if [ "$TAG" == "${RUNNER_NAME}_http" ]; then
+        PORT=$(RUNNER_NAME=$TAG docker compose -f docker-compose.yml port nginx 80 | cut -d: -f2)
+    else
+        PORT=$(RUNNER_NAME=$TAG docker compose -f docker-compose.yml port lenz 55551 | cut -d: -f2)
+    fi
+    echo "$GATEWAY:$PORT"
 }
 
 IP_REGEX='[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}'

--- a/test/test_Datawizard.py
+++ b/test/test_Datawizard.py
@@ -123,7 +123,7 @@ def make_people(count: int = 1) -> List[object]:
 
     people = []
     for i in range(10):
-        person = Person(name=f"adam{i+1}")
+        person = Person(name=f"adam{i + 1}")
         left_hand = make_hand(Side.LEFT)
         right_hand = make_hand(Side.RIGHT)
         person.hands.extend([left_hand, right_hand])

--- a/test/test_Datawizard.py
+++ b/test/test_Datawizard.py
@@ -115,7 +115,7 @@ def make_people(count: int = 1) -> List[object]:
         dominant_hand: Hand = None
 
     def make_hand(side: Side) -> Hand:
-        hand = Hand(side = side, url= "input/images/0079.jpg")
+        hand = Hand(side=side, url="input/images/0079.jpg")
         hand.fingers = [Finger(nail_clean=True) if random.randint(
             0, 1) == 1 else Finger(nail_clean=False) for i in range(5)]
         hand.thumb = hand.fingers[0]

--- a/test/test_Images.py
+++ b/test/test_Images.py
@@ -1,0 +1,116 @@
+import numpy as np
+from aperturedb.Images import Images, resolve, rotate
+from unittest.mock import patch
+
+
+def test_rotate():
+    points = np.array([(10, 10), (20, 20)])
+    rotated = rotate(points, 90, c_x=10, c_y=10)
+    assert len(rotated) == 2
+    assert rotated[0][0] == 10 and rotated[0][1] == 10
+    assert rotated[1][0] == 0 and rotated[1][1] == 20
+
+
+def test_resolve_resize():
+    points = np.array([[10, 10], [20, 20]], dtype=float)
+    meta = {"adb_image_width": 100, "adb_image_height": 100}
+    operations = [{"type": "resize", "width": 50, "height": 50}]
+    resolved = resolve(points, meta, operations)
+    assert resolved[0][0] == 5
+    assert resolved[0][1] == 5
+    assert resolved[1][0] == 10
+    assert resolved[1][1] == 10
+
+
+def test_resolve_rotate():
+    points = np.array([[10, 10]], dtype=float)
+    meta = {"adb_image_width": 100, "adb_image_height": 100}
+    operations = [{"type": "rotate", "angle": 90}]
+    resolved = resolve(points, meta, operations)
+    assert len(resolved) == 1
+    # Note: 9 instead of 10 due to float truncation in .astype(int)
+    assert resolved[0][0] == 90 and resolved[0][1] == 9
+
+
+class MockClient:
+    def __init__(self):
+        self.responses = []
+        self.queries = []
+
+    def query(self, q, blobs=None):
+        if blobs is None:
+            blobs = []
+        self.queries.append(q)
+        return self.responses.pop(0) if self.responses else ([{}], [])
+
+    def last_query_ok(self):
+        return True
+
+
+def test_Images_init():
+    client = MockClient()
+    img = Images(client)
+    assert img.client == client
+    assert img.db_object.value == "_Image"
+
+
+def test_Images_search():
+    client = MockClient()
+    with patch('aperturedb.Images.execute_query') as mock_execute:
+        mock_execute.return_value = (
+            0, [{"FindImage": {"entities": [{"_uniqueid": "123"}, {"_uniqueid": "456"}]}}], [])
+        img = Images(client)
+        img.search(limit=2)
+        assert "123" in img.images_ids
+        assert "456" in img.images_ids
+        mock_execute.assert_called_once()
+        query_passed = mock_execute.call_args[1][
+            "query"] if "query" in mock_execute.call_args[1] else mock_execute.call_args[0][1]
+        assert "FindImage" in query_passed[0]
+        assert query_passed[0]["FindImage"]["results"]["limit"] == 2
+
+
+def test_Images_search_by_property():
+    client = MockClient()
+    with patch('aperturedb.Images.execute_query') as mock_execute:
+        mock_execute.return_value = (
+            0, [{"FindImage": {"entities": [{"_uniqueid": "789"}]}}], [])
+        img = Images(client)
+        img.search_by_property("label", ["test_label"])
+        assert "789" in img.images_ids
+        query_passed = mock_execute.call_args[1][
+            "query"] if "query" in mock_execute.call_args[1] else mock_execute.call_args[0][1]
+        assert "constraints" in query_passed[0]["FindImage"]
+
+
+def test_Images_get_image_by_index():
+    client = MockClient()
+    img = Images(client)
+    img.images_ids = ["111"]
+
+    with patch('aperturedb.Images.execute_query') as mock_execute:
+        mock_execute.return_value = (0, [], [b'fakeimageblob'])
+        # Override last_query_ok since MockClient does that
+        client.last_query_ok = lambda: True
+
+        res = img.get_image_by_index(0)
+        assert res == b'fakeimageblob'
+        assert "111" in img.images
+
+
+def test_Images_get_np_image_by_index():
+    client = MockClient()
+    img = Images(client)
+    img.images_ids = ["111"]
+
+    with patch('aperturedb.Images.execute_query') as mock_execute:
+        # Create a small valid jpeg or png mock blob
+        import cv2
+        fake_np = np.zeros((10, 10, 3), dtype=np.uint8)
+        _, fake_blob = cv2.imencode('.jpg', fake_np)
+
+        mock_execute.return_value = (0, [], [fake_blob.tobytes()])
+        client.last_query_ok = lambda: True
+
+        res = img.get_np_image_by_index(0)
+        assert res.shape == (10, 10, 3)

--- a/test/test_Server.py
+++ b/test/test_Server.py
@@ -62,8 +62,12 @@ class TestBadResponses():
                             "entity": {"_Image": {"id"}}})
         input_data = pd.read_csv("./input/images.adb.csv")
         data, loader = insert_data_from_csv(
-            in_csv_file = "./input/images.adb.csv", expected_error_count = len(input_data))
-        assert loader.error_counter == 0, f"Error counter: {loader.error_counter=}"
+            in_csv_file="./input/images.adb.csv",
+            expected_error_count=len(input_data)
+        )
+        assert loader.error_counter == 0, (
+            f"Error counter: {loader.error_counter=}"
+        )
         assert loader.get_succeeded_queries(
         ) == 0, f"Queries: {loader.get_succeeded_queries()=}"
         assert loader.get_succeeded_commands(

--- a/test/test_Session.py
+++ b/test/test_Session.py
@@ -265,3 +265,28 @@ class TestSession():
         resp, blobs = db.query([{'GetSchema': {}}], [])
         print(f"{resp=}")
         assert enable_mock == False, "Authentication query was not invoked"
+
+    def test_connect_at_construction(self, monkeypatch):
+        # We want to test that connect() is called when connect=True.
+        # mock connect so it doesn't fail on missing server
+        def mock_connect(self):
+            self.connected = True
+        monkeypatch.setattr(Connector, "connect", mock_connect)
+
+        new_db = Connector(
+            dbinfo.DB_TCP_HOST,
+            dbinfo.DB_TCP_PORT,
+            dbinfo.DB_USER,
+            dbinfo.DB_PASSWORD,
+            ca_cert=dbinfo.CA_CERT,
+            connect=True)
+        assert getattr(new_db, "connected", False) == True
+
+        # also test default behavior
+        new_db_lazy = Connector(
+            dbinfo.DB_TCP_HOST,
+            dbinfo.DB_TCP_PORT,
+            dbinfo.DB_USER,
+            dbinfo.DB_PASSWORD,
+            ca_cert=dbinfo.CA_CERT)
+        assert getattr(new_db_lazy, "connected", False) == False

--- a/test/test_Session.py
+++ b/test/test_Session.py
@@ -271,6 +271,10 @@ class TestSession():
         # mock connect so it doesn't fail on missing server
         def mock_connect(self):
             self.connected = True
+
+            class MockConn:
+                def close(self): pass
+            self.conn = MockConn()
         monkeypatch.setattr(Connector, "connect", mock_connect)
 
         new_db = Connector(

--- a/test/test_Stats.py
+++ b/test/test_Stats.py
@@ -44,6 +44,6 @@ class TestStats():
         out = self.ingest_with_capture(data, db)
         assertions = {
             "Total inserted elements": lambda x: float(x) == 0,
-            "Overall insertion throughput (element/s)": lambda x: x == "NaN",
+            "Overall insertion throughput (element/s)": lambda x: float(x) == 0,
         }
         self.validate_stats(out, assertions)

--- a/test/test_Stats.py
+++ b/test/test_Stats.py
@@ -31,8 +31,10 @@ class TestStats():
                     first, second = line.split(":")
                     print(first, second)
                     if first in assertions:
-                        assert assertions[first.strip()](second.strip()) == True, \
-                            f"Assertion failed for '{first}' with value {second}"
+                        assert assertions[first.strip()](second.strip()) is True, (
+                            f"Assertion failed for '{first}' "
+                            f"with value {second}"
+                        )
 
     def test_stats_all_errors_non_equal_last_batch(self, db, utils):
         utils.remove_all_objects()


### PR DESCRIPTION
## Summary
* Decoupled `use_dask` from CSVParser logic and kwargs.
* Added `use_dask` as a parameter to `Parallelizer` and its children (`ParallelQuery`, `ParallelLoader`).
* Updated generator classes (`ImageDataCSV`, `VideoDataCSV`, etc.) to use `isinstance(self.df, dask.dataframe.DataFrame)` to determine if Dask parallelization is in use, avoiding `use_dask` tracking directly in the generator objects.
* Modified `cli/ingest.py` to directly instantiate and pass the `dask.dataframe` object instead of using `use_dask=True` flag in the generators, making out-of-core reading explicit for Dask executions.

## Verification
* Passed CLI tests using `pytest`.

Fixes aperture-data/aperturedb-python#233