### PR TITLE
feat: generalize and refactor connection pool from workflows

### DIFF
--- a/aperturedb/ConnectionPool.py
+++ b/aperturedb/ConnectionPool.py
@@ -17,7 +17,7 @@ class ConnectionPool:
     threads to safely execute queries by borrowing and returning connections.
     """
 
-    def __init__(self, pool_size: int = 10, connection_factory: Callable[..., Any] = create_connector, *args, **kwargs):
+    def __init__(self, pool_size: int = 10, *args, connection_factory: Callable[..., Any] = create_connector, **kwargs):
         """
         Initializes the connection pool.
 
@@ -35,9 +35,6 @@ class ConnectionPool:
         # A thread-safe queue to hold the available connections
         self._pool = queue.Queue(maxsize=pool_size)
 
-        # A lock to ensure the initial population is thread-safe, just in case.
-        self._lock = threading.Lock()
-
         # Pre-populate the pool with connections
         for _ in range(pool_size):
             try:
@@ -45,19 +42,15 @@ class ConnectionPool:
                 if not connection:
                     raise ConnectionError("Failed to create a connection.")
                 self._pool.put(connection)
-            except Exception as e:
-                logger.error(f"Failed to create a connection for the pool: {e}")
-                # Depending on requirements, you might want to raise an error
-                # if the pool cannot be fully populated.
-
-        if self.available() == 0:
-            raise ConnectionError(
-                "Failed to initialize any connections for the pool. "
-                "Please check connection parameters and network."
-            )
+            except Exception:
+                logger.exception("Failed to create a connection for the pool")
+                raise
 
     def available(self) -> int:
-        """Returns the number of available connections in the pool."""
+        """Returns the number of available connections in the pool.
+        
+        (Note: This is an approximate value and primarily for monitoring.)
+        """
         return self._pool.qsize()
 
     def total(self) -> int:

--- a/aperturedb/ConnectionPool.py
+++ b/aperturedb/ConnectionPool.py
@@ -48,7 +48,7 @@ class ConnectionPool:
 
     def available(self) -> int:
         """Returns the number of available connections in the pool.
-        
+
         (Note: This is an approximate value and primarily for monitoring.)
         """
         return self._pool.qsize()
@@ -96,6 +96,6 @@ class ConnectionPool:
         """
         if blobs is None:
             blobs = []
-            
+
         with self.get_connection() as connection:
             return connection.query(query, blobs, **kwargs)

--- a/aperturedb/ConnectionPool.py
+++ b/aperturedb/ConnectionPool.py
@@ -1,0 +1,108 @@
+import logging
+import threading
+import queue
+from contextlib import contextmanager
+from typing import Callable, Any, Optional
+
+from aperturedb.CommonLibrary import create_connector
+
+logger = logging.getLogger(__name__)
+
+
+class ConnectionPool:
+    """
+    A thread-safe connection pool for aperturedb.Connector.
+
+    This pool manages a fixed number of Connector instances, allowing multiple
+    threads to safely execute queries by borrowing and returning connections.
+    """
+
+    def __init__(self, pool_size: int = 10, connection_factory: Callable[..., Any] = create_connector, *args, **kwargs):
+        """
+        Initializes the connection pool.
+
+        Args:
+            pool_size (int): The number of connections to keep in the pool.
+            connection_factory (callable): A factory function to create new connections.
+            *args: Positional arguments to pass to the connection_factory.
+            **kwargs: Keyword arguments to pass to the connection_factory.
+        """
+        if pool_size <= 0:
+            raise ValueError("Pool size must be greater than 0.")
+
+        self._pool_size = pool_size
+        self._connection_factory = connection_factory
+        # A thread-safe queue to hold the available connections
+        self._pool = queue.Queue(maxsize=pool_size)
+
+        # A lock to ensure the initial population is thread-safe, just in case.
+        self._lock = threading.Lock()
+
+        # Pre-populate the pool with connections
+        for _ in range(pool_size):
+            try:
+                connection = self._connection_factory(*args, **kwargs)
+                if not connection:
+                    raise ConnectionError("Failed to create a connection.")
+                self._pool.put(connection)
+            except Exception as e:
+                logger.error(f"Failed to create a connection for the pool: {e}")
+                # Depending on requirements, you might want to raise an error
+                # if the pool cannot be fully populated.
+
+        if self.available() == 0:
+            raise ConnectionError(
+                "Failed to initialize any connections for the pool. "
+                "Please check connection parameters and network."
+            )
+
+    def available(self) -> int:
+        """Returns the number of available connections in the pool."""
+        return self._pool.qsize()
+
+    def total(self) -> int:
+        """Returns the total number of connections in the pool."""
+        return self._pool_size
+
+    @contextmanager
+    def get_connection(self):
+        """
+        A context manager to get a connection from the pool.
+        This is the recommended way to use a connection.
+        It automatically gets a connection and releases it back to the pool.
+
+        Usage:
+            with pool.get_connection() as conn:
+                conn.query(...)
+        """
+        # The get() call will block until a connection is available.
+        connection = self._pool.get()
+        try:
+            # Yield the connection for the user to use
+            yield connection
+        finally:
+            # This block is guaranteed to execute, ensuring the connection
+            # is always returned to the pool.
+            self._pool.put(connection)
+
+    def query(self, query: str, blobs: Optional[list] = None, **kwargs):
+        """
+        A convenience method to execute a query directly from the pool.
+
+        This method handles getting a connection, executing the query,
+        and returning the connection to the pool.
+
+        Args:
+            query (str): The query string to execute.
+            blobs (list): A list of blobs to include with the query.
+            **kwargs: Other arguments for the Connector's query method.
+
+        Returns:
+            Response from the executed query.
+            Blobs
+        """
+        if blobs is None:
+            blobs = []
+            
+        with self.get_connection() as connection:
+            return connection.query(query, blobs, **kwargs)

--- a/test/test_ConnectionPool.py
+++ b/test/test_ConnectionPool.py
@@ -1,0 +1,48 @@
+import pytest
+from unittest.mock import MagicMock
+from aperturedb.ConnectionPool import ConnectionPool
+
+def test_connection_pool_init():
+    mock_connector = MagicMock()
+    mock_factory = MagicMock(return_value=mock_connector)
+    
+    pool = ConnectionPool(pool_size=5, connection_factory=mock_factory)
+    
+    assert pool.total() == 5
+    assert pool.available() == 5
+    assert mock_factory.call_count == 5
+
+def test_connection_pool_invalid_size():
+    with pytest.raises(ValueError):
+        ConnectionPool(pool_size=0)
+
+def test_connection_pool_get_connection():
+    mock_connector = MagicMock()
+    mock_factory = MagicMock(return_value=mock_connector)
+    
+    pool = ConnectionPool(pool_size=2, connection_factory=mock_factory)
+    
+    with pool.get_connection() as conn:
+        assert conn == mock_connector
+        assert pool.available() == 1
+        
+    assert pool.available() == 2
+
+def test_connection_pool_query():
+    mock_connector = MagicMock()
+    mock_connector.query.return_value = (MagicMock(), [])
+    mock_factory = MagicMock(return_value=mock_connector)
+    
+    pool = ConnectionPool(pool_size=2, connection_factory=mock_factory)
+    
+    res, blobs = pool.query("Some query", blobs=[])
+    
+    assert pool.available() == 2
+    mock_connector.query.assert_called_once_with("Some query", [], **{})
+
+def test_connection_pool_args():
+    mock_connector = MagicMock()
+    mock_factory = MagicMock(return_value=mock_connector)
+    
+    pool = ConnectionPool(pool_size=2, connection_factory=mock_factory, arg1="value1", arg2="value2")
+    mock_factory.assert_called_with(arg1="value1", arg2="value2")

--- a/test/test_ConnectionPool.py
+++ b/test/test_ConnectionPool.py
@@ -2,48 +2,55 @@ import pytest
 from unittest.mock import MagicMock, call
 from aperturedb.ConnectionPool import ConnectionPool
 
+
 def test_connection_pool_init():
     mock_connector = MagicMock()
     mock_factory = MagicMock(return_value=mock_connector)
-    
+
     pool = ConnectionPool(pool_size=5, connection_factory=mock_factory)
-    
+
     assert pool.total() == 5
     assert pool.available() == 5
     assert mock_factory.call_count == 5
+
 
 def test_connection_pool_invalid_size():
     with pytest.raises(ValueError):
         ConnectionPool(pool_size=0)
 
+
 def test_connection_pool_get_connection():
     mock_connector = MagicMock()
     mock_factory = MagicMock(return_value=mock_connector)
-    
+
     pool = ConnectionPool(pool_size=2, connection_factory=mock_factory)
-    
+
     with pool.get_connection() as conn:
         assert conn == mock_connector
         assert pool.available() == 1
-        
+
     assert pool.available() == 2
+
 
 def test_connection_pool_query():
     mock_connector = MagicMock()
     mock_connector.query.return_value = (MagicMock(), [])
     mock_factory = MagicMock(return_value=mock_connector)
-    
+
     pool = ConnectionPool(pool_size=2, connection_factory=mock_factory)
-    
+
     res, blobs = pool.query("Some query", blobs=[])
-    
+
     assert pool.available() == 2
     mock_connector.query.assert_called_once_with("Some query", [], **{})
+
 
 def test_connection_pool_args():
     mock_connector = MagicMock()
     mock_factory = MagicMock(return_value=mock_connector)
-    
-    pool = ConnectionPool(2, "arg1_val", "arg2_val", connection_factory=mock_factory, kwarg1="value1")
+
+    pool = ConnectionPool(2, "arg1_val", "arg2_val",
+                          connection_factory=mock_factory, kwarg1="value1")
     assert mock_factory.call_count == 2
-    mock_factory.assert_has_calls([call("arg1_val", "arg2_val", kwarg1="value1")] * 2)
+    mock_factory.assert_has_calls(
+        [call("arg1_val", "arg2_val", kwarg1="value1")] * 2)

--- a/test/test_ConnectionPool.py
+++ b/test/test_ConnectionPool.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 from aperturedb.ConnectionPool import ConnectionPool
 
 def test_connection_pool_init():
@@ -44,5 +44,6 @@ def test_connection_pool_args():
     mock_connector = MagicMock()
     mock_factory = MagicMock(return_value=mock_connector)
     
-    pool = ConnectionPool(pool_size=2, connection_factory=mock_factory, arg1="value1", arg2="value2")
-    mock_factory.assert_called_with(arg1="value1", arg2="value2")
+    pool = ConnectionPool(2, "arg1_val", "arg2_val", connection_factory=mock_factory, kwarg1="value1")
+    assert mock_factory.call_count == 2
+    mock_factory.assert_has_calls([call("arg1_val", "arg2_val", kwarg1="value1")] * 2)


### PR DESCRIPTION
## Summary
Incorporated the connection pool from `workflows` repository into the `aperturedb-python` module. Generalized the implementation by adding support for passing generic arguments to the connection factory, replaced standard print statements with the logging module, and avoided mutable default arguments.

## Verification
- Added `test_ConnectionPool.py` unit tests and verified all pass locally.

Fixes aperture-data/aperturedb-python#598.
