### PR TITLE
fix(logging): redact sensitive tokens in query objects

### DIFF
--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -266,14 +266,12 @@ def create_connector(
     return __create_connector(config)
 
 
-
-
 def censor_tokens(data):
     """
     Recursively redact sensitive token fields in a dictionary or list.
     """
     import copy
-    
+
     def censor_string(v):
         if not isinstance(v, str):
             return v
@@ -284,7 +282,7 @@ def censor_tokens(data):
         else:
             prefix = ""
             token = v
-        
+
         if len(token) > 8:
             return prefix + token[:4] + "..." + token[-4:]
         elif len(v) > 0:
@@ -310,10 +308,11 @@ def censor_tokens(data):
         elif isinstance(obj, list):
             for item in obj:
                 _censor(item)
-    
+
     censored = copy.deepcopy(data)
     _censor(censored)
     return censored
+
 
 def execute_query(client: Connector, query: Commands,
                   blobs: Blobs = [],
@@ -364,7 +363,8 @@ def execute_query(client: Connector, query: Commands,
                     raise e
     else:
         # Transaction failed entirely.
-        logger.error(f"Failed query = {censor_tokens(query)} with response = {censor_tokens(r)}")
+        logger.error(f"Failed query = {censor_tokens(
+            query)} with response = {censor_tokens(r)}")
         result = 1
 
     statuses = {}

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -266,6 +266,41 @@ def create_connector(
     return __create_connector(config)
 
 
+
+
+def censor_tokens(data):
+    """
+    Recursively redact sensitive token fields in a dictionary or list.
+    """
+    import copy
+    
+    def _censor(obj):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if isinstance(k, str) and k.lower() in ["refresh_token", "session_token", "token", "access_token"]:
+                    if isinstance(v, str):
+                        parts = v.split("_", 1)
+                        if len(parts) == 2:
+                            prefix = parts[0] + "_"
+                            token = parts[1]
+                        else:
+                            prefix = ""
+                            token = v
+                        
+                        if len(token) > 8:
+                            obj[k] = prefix + token[:4] + "..." + token[-4:]
+                        elif len(v) > 0:
+                            obj[k] = prefix + "..."
+                else:
+                    _censor(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                _censor(item)
+    
+    censored = copy.deepcopy(data)
+    _censor(censored)
+    return censored
+
 def execute_query(client: Connector, query: Commands,
                   blobs: Blobs = [],
                   success_statuses: list[int] = [0],
@@ -297,9 +332,9 @@ def execute_query(client: Connector, query: Commands,
         Blobs: The blobs.
     """
     result = 0
-    logger.debug(f"Query={query}")
+    logger.debug(f"Query={censor_tokens(query)}")
     r, b = client.query(query, blobs)
-    logger.debug(f"Response={r}")
+    logger.debug(f"Response={censor_tokens(r)}")
 
     if client.last_query_ok():
         if response_handler is not None:
@@ -313,7 +348,7 @@ def execute_query(client: Connector, query: Commands,
                     raise e
     else:
         # Transaction failed entirely.
-        logger.error(f"Failed query = {query} with response = {r}")
+        logger.error(f"Failed query = {censor_tokens(query)} with response = {censor_tokens(r)}")
         result = 1
 
     statuses = {}
@@ -337,7 +372,7 @@ def execute_query(client: Connector, query: Commands,
                     warn_list.append(wr)
         if len(warn_list) != 0:
             logger.warning(
-                f"Partial errors:\r\n{json.dumps(query, default=str)}\r\n{json.dumps(warn_list, default=str)}")
+                f"Partial errors:\r\n{json.dumps(censor_tokens(query), default=str)}\r\n{json.dumps(censor_tokens(warn_list), default=str)}")
             result = 2
 
     return result, r, b

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -274,23 +274,37 @@ def censor_tokens(data):
     """
     import copy
     
+    def censor_string(v):
+        if not isinstance(v, str):
+            return v
+        parts = v.split("_", 1)
+        if len(parts) == 2:
+            prefix = parts[0] + "_"
+            token = parts[1]
+        else:
+            prefix = ""
+            token = v
+        
+        if len(token) > 8:
+            return prefix + token[:4] + "..." + token[-4:]
+        elif len(v) > 0:
+            return prefix + "..."
+        return v
+
     def _censor(obj):
         if isinstance(obj, dict):
             for k, v in obj.items():
-                if isinstance(k, str) and k.lower() in ["refresh_token", "session_token", "token", "access_token"]:
+                if isinstance(k, str) and (k.lower().endswith("token") or k.lower().endswith("tokens")):
                     if isinstance(v, str):
-                        parts = v.split("_", 1)
-                        if len(parts) == 2:
-                            prefix = parts[0] + "_"
-                            token = parts[1]
-                        else:
-                            prefix = ""
-                            token = v
-                        
-                        if len(token) > 8:
-                            obj[k] = prefix + token[:4] + "..." + token[-4:]
-                        elif len(v) > 0:
-                            obj[k] = prefix + "..."
+                        obj[k] = censor_string(v)
+                    elif isinstance(v, list):
+                        for i in range(len(v)):
+                            if isinstance(v[i], str):
+                                v[i] = censor_string(v[i])
+                            else:
+                                _censor(v[i])
+                    else:
+                        _censor(v)
                 else:
                     _censor(v)
         elif isinstance(obj, list):
@@ -332,9 +346,11 @@ def execute_query(client: Connector, query: Commands,
         Blobs: The blobs.
     """
     result = 0
-    logger.debug(f"Query={censor_tokens(query)}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(f"Query={censor_tokens(query)}")
     r, b = client.query(query, blobs)
-    logger.debug(f"Response={censor_tokens(r)}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(f"Response={censor_tokens(r)}")
 
     if client.last_query_ok():
         if response_handler is not None:

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -283,10 +283,8 @@ def censor_tokens(data):
             prefix = ""
             token = v
 
-        if len(token) > 8:
-            return prefix + token[:4] + "..." + token[-4:]
-        elif len(v) > 0:
-            return prefix + "..."
+        if len(token) > 0:
+            return prefix + "<redacted>"
         return v
 
     def _censor(obj):
@@ -363,8 +361,7 @@ def execute_query(client: Connector, query: Commands,
                     raise e
     else:
         # Transaction failed entirely.
-        logger.error(f"Failed query = {censor_tokens(
-            query)} with response = {censor_tokens(r)}")
+        logger.error(f"Failed query = {censor_tokens(query)} with response = {censor_tokens(r)}")
         result = 1
 
     statuses = {}

--- a/aperturedb/Entities.py
+++ b/aperturedb/Entities.py
@@ -5,7 +5,7 @@ from aperturedb.Query import Query, ObjectType
 from aperturedb.Subscriptable import Subscriptable
 from aperturedb.Constraints import Constraints
 from aperturedb.Connector import Connector
-from aperturedb.CommonLibrary import execute_query
+from aperturedb.CommonLibrary import execute_query, censor_tokens
 from aperturedb.Query import QueryBuilder
 import pandas as pd
 import logging
@@ -71,8 +71,8 @@ class Entities(Subscriptable):
         cls.client = client
 
         query = spec.query()
-        from aperturedb.CommonLibrary import censor_tokens
-        logger.debug(f"query={censor_tokens(query)}")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"query={censor_tokens(query)}")
         res, r, b = execute_query(client, query, [])
         if res > 0:
             logger.warning(f"resp={r}")

--- a/aperturedb/Entities.py
+++ b/aperturedb/Entities.py
@@ -71,7 +71,8 @@ class Entities(Subscriptable):
         cls.client = client
 
         query = spec.query()
-        logger.debug(f"query={query}")
+        from aperturedb.CommonLibrary import censor_tokens
+        logger.debug(f"query={censor_tokens(query)}")
         res, r, b = execute_query(client, query, [])
         if res > 0:
             logger.warning(f"resp={r}")

--- a/aperturedb/Entities.py
+++ b/aperturedb/Entities.py
@@ -75,7 +75,7 @@ class Entities(Subscriptable):
             logger.debug(f"query={censor_tokens(query)}")
         res, r, b = execute_query(client, query, [])
         if res > 0:
-            logger.warning(f"resp={r}")
+            logger.warning(f"resp={censor_tokens(r)}")
         results = []
         for wc, req, blobs, resp in zip(
                 spec.command_properties(prop="with_class"),

--- a/examples/rest_api/rest_api.js
+++ b/examples/rest_api/rest_api.js
@@ -3,7 +3,7 @@ const request = (query, blobs, handler, sessionToken) => {
     const formData = new FormData();
     formData.append('query', JSON.stringify(query));
     displayContent(query, response=false);
-    
+
     blobs.forEach(element => {
         formData.append('blobs', element);
     });
@@ -15,7 +15,7 @@ const request = (query, blobs, handler, sessionToken) => {
             "Authorization": `Bearer ${sessionToken}`
         }
     }
-    
+
     axios.post(
             url=apiURL,
             data=formData, {
@@ -49,7 +49,7 @@ run_requests = () => {
         // console.log(authData[0]);
         displayContent(authData);
         sessionToken = authData[0].Authenticate.session_token;
-        
+
 
         //List images
         listQuery = [{
@@ -98,8 +98,8 @@ run_requests = () => {
         sessionStorage.setItem("session_token", sessionToken);
     })
 
-    
-    
+
+
 }
 
 const addImage = (event) => {
@@ -116,7 +116,7 @@ const addImage = (event) => {
         response = data["json"];
         displayContent(response);
     }, sessionToken = sessionStorage.getItem("session_token"));
-    
+
 }
 
 window.addEventListener("load", (event)=>{


### PR DESCRIPTION
### Summary
This PR applies `censor_tokens` to the `query` objects before they are serialized and logged in `CommonLibrary.py` and `Entities.py`. This prevents credentials such as `token`, `refresh_token`, and `add_tokens` from leaking into system logs.

### Verification
- Tested locally by running `pytest` tests.
- Verified that `censor_tokens` masks any value corresponding to `token`, `refresh_token`, `session_token`, or `access_token`.

Fixes #707