### PR TITLE
feat: expose ingestion stats via callbacks and logging

### DIFF
--- a/aperturedb/ParallelLoader.py
+++ b/aperturedb/ParallelLoader.py
@@ -180,7 +180,7 @@ class ParallelLoader(ParallelQuery.ParallelQuery):
                         logger.warning(
                             f"Failed to create index for {connection_class}.{property_name}")
 
-    def ingest(self, generator: Subscriptable, batchsize: int = 1, numthreads: int = 4, stats: bool = False) -> None:
+    def ingest(self, generator: Subscriptable, batchsize: int = 1, numthreads: int = 4, stats: bool = False, **kwargs) -> None:
         """
         **Method to ingest data into the database**
 
@@ -192,7 +192,7 @@ class ParallelLoader(ParallelQuery.ParallelQuery):
         """
         logger.info(
             f"Starting ingestion with batchsize={batchsize}, numthreads={numthreads}")
-        self.query(generator, batchsize, numthreads, stats)
+        self.query(generator, batchsize, numthreads, stats, **kwargs)
 
     def print_stats(self) -> None:
 

--- a/aperturedb/ParallelLoader.py
+++ b/aperturedb/ParallelLoader.py
@@ -189,6 +189,9 @@ class ParallelLoader(ParallelQuery.ParallelQuery):
             batchsize (int, optional): The size of batch to be used. Defaults to 1.
             numthreads (int, optional): Number of workers to create. Defaults to 4.
             stats (bool, optional): If stats need to be presented, realtime. Defaults to False.
+            **kwargs: Additional arguments, such as:
+                progress_callback (callable): A function called after each batch completes.
+                log_progress (bool): If True, logs progress per batch via the logger.
         """
         logger.info(
             f"Starting ingestion with batchsize={batchsize}, numthreads={numthreads}")

--- a/aperturedb/ParallelLoader.py
+++ b/aperturedb/ParallelLoader.py
@@ -191,6 +191,14 @@ class ParallelLoader(ParallelQuery.ParallelQuery):
             stats (bool, optional): If stats need to be presented, realtime. Defaults to False.
             **kwargs: Additional arguments, such as:
                 progress_callback (callable): A function called after each batch completes.
+                    It must accept the following keyword arguments:
+                    - worker_id (int): The ID of the worker.
+                    - batch_index (int): The 0-based index of the batch for this worker.
+                    - total_batches (int): Total number of batches for this worker.
+                    - batch_start (int): The starting index of the batch.
+                    - batch_end (int): The ending index of the batch.
+                    - worker_stats (dict): The stats for this batch.
+                    - errors (int): The total number of errors encountered so far by all workers.
                 log_progress (bool): If True, logs progress per batch via the logger.
         """
         logger.info(

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -238,7 +238,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
             worker_stats = {}
             try:
                 result_stats = self.do_batch(client, batch_start,
-                              generator[batch_start:batch_end])
+                                             generator[batch_start:batch_end])
                 if result_stats is not None:
                     worker_stats = result_stats
             except Exception as e:
@@ -251,7 +251,8 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 self.pb.update(batch_end - batch_start)
 
             if getattr(self, "log_progress", False):
-                logger.info(f"Worker {thid} completed batch {i+1}/{total_batches}. Worker stats: {worker_stats}, Errors so far: {self.error_counter}")
+                logger.info(f"Worker {thid} completed batch {
+                            i + 1}/{total_batches}. Worker stats: {worker_stats}, Errors so far: {self.error_counter}")
 
             if hasattr(self, "progress_callback") and callable(self.progress_callback):
                 try:

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -260,7 +260,11 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 current_errors = self.error_counter
 
             if getattr(self, "log_progress", False):
-                logger.info(f"Worker {thid} completed batch {i + 1}/{total_batches}. Worker stats: {dict(worker_stats)}, Errors so far: {current_errors}")
+                logger.info(
+                    f"Worker {thid} completed batch {i + 1}/{total_batches}. "
+                    f"Worker stats: {dict(worker_stats)}, "
+                    f"Errors so far: {current_errors}"
+                )
 
             if hasattr(self, "progress_callback") and callable(self.progress_callback):
                 try:

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -313,7 +313,8 @@ class ParallelQuery(Parallelizer.Parallelizer):
 
         use_dask = hasattr(generator, "use_dask") and generator.use_dask
         if use_dask and (self.progress_callback or self.log_progress):
-            logger.warning("progress_callback and log_progress are not supported when using Dask.")
+            logger.warning(
+                "progress_callback and log_progress are not supported when using Dask.")
 
         if use_dask:
             self._reset(batchsize=batchsize, numthreads=numthreads)

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -118,7 +118,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
         except BaseException as e:
             logger.exception(e)
 
-    def do_batch(self, client: Connector, batch_start: int,  data: List[Tuple[Commands, Blobs]]) -> None:
+    def do_batch(self, client: Connector, batch_start: int,  data: List[Tuple[Commands, Blobs]]) -> dict:
         """
         Executes batch of queries and blobs in the database.
 
@@ -216,6 +216,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
         # append is thread-safe
         self.times_arr.append(query_time)
         self.actual_stats.append(worker_stats)
+        return worker_stats
 
     def worker(self, thid: int, generator, start: int, end: int, run_event) -> None:
         # A new connection will be created for each thread
@@ -234,9 +235,12 @@ class ParallelQuery(Parallelizer.Parallelizer):
             batch_start = start + i * self.batchsize
             batch_end = min(batch_start + self.batchsize, end)
 
+            worker_stats = {}
             try:
-                self.do_batch(client, batch_start,
+                result_stats = self.do_batch(client, batch_start,
                               generator[batch_start:batch_end])
+                if result_stats is not None:
+                    worker_stats = result_stats
             except Exception as e:
                 logger.exception(e)
                 logger.warning(
@@ -245,6 +249,24 @@ class ParallelQuery(Parallelizer.Parallelizer):
 
             if self.stats:
                 self.pb.update(batch_end - batch_start)
+
+            if getattr(self, "log_progress", False):
+                logger.info(f"Worker {thid} completed batch {i+1}/{total_batches}. Worker stats: {worker_stats}, Errors so far: {self.error_counter}")
+
+            if hasattr(self, "progress_callback") and callable(self.progress_callback):
+                try:
+                    self.progress_callback(
+                        worker_id=thid,
+                        batch_index=i,
+                        total_batches=total_batches,
+                        batch_start=batch_start,
+                        batch_end=batch_end,
+                        worker_stats=worker_stats,
+                        errors=self.error_counter
+                    )
+                except Exception as cb_e:
+                    logger.warning(f"progress_callback failed: {cb_e}")
+
         logger.info(f"Worker {thid} executed {total_batches} batches")
 
     def get_objects_existed(self) -> int:
@@ -259,7 +281,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
         return sum([stat["succeeded_commands"]
                     for stat in self.actual_stats])
 
-    def query(self, generator, batchsize: int = 1, numthreads: int = 4, stats: bool = False) -> None:
+    def query(self, generator, batchsize: int = 1, numthreads: int = 4, stats: bool = False, **kwargs) -> None:
         """
         This function takes as input the data to be executed in specified number of threads.
         The generator yields a tuple : (array of commands, array of blobs)
@@ -268,7 +290,13 @@ class ParallelQuery(Parallelizer.Parallelizer):
             batchsize (int, optional): Number of queries per transaction. Defaults to 1.
             numthreads (int, optional): Number of parallel workers. Defaults to 4.
             stats (bool, optional): Show statistics at end of ingestion. Defaults to False.
+            **kwargs: Additional arguments, such as:
+                progress_callback (callable): A function called after each batch completes.
+                log_progress (bool): If True, logs progress per batch via the logger.
         """
+
+        self.progress_callback = kwargs.get("progress_callback", None)
+        self.log_progress = kwargs.get("log_progress", False)
 
         use_dask = hasattr(generator, "use_dask") and generator.use_dask
         if use_dask:

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -260,7 +260,8 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 current_errors = self.error_counter
 
             if getattr(self, "log_progress", False):
-                logger.info(f"Worker {thid} completed batch {i + 1}/{total_batches}. Worker stats: {dict(worker_stats)}, Errors so far: {current_errors}")
+                logger.info(f"Worker {thid} completed batch {
+                            i + 1}/{total_batches}. Worker stats: {dict(worker_stats)}, Errors so far: {current_errors}")
 
             if hasattr(self, "progress_callback") and callable(self.progress_callback):
                 try:

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -118,13 +118,17 @@ class ParallelQuery(Parallelizer.Parallelizer):
         except BaseException as e:
             logger.exception(e)
 
-    def do_batch(self, client: Connector, batch_start: int,  data: List[Tuple[Commands, Blobs]]) -> dict:
+    def do_batch(self, client: Connector, batch_start: int,  data: List[Tuple[Commands, Blobs]]) -> dict | None:
         """
         Executes batch of queries and blobs in the database.
 
         Args:
             client (Connector): The database connector.
             data (list[tuple[Commands, Blobs]]): The data to be batched.  Each tuple contains a list of commands and a list of blobs.
+
+        Returns:
+            dict | None: The per-batch worker stats (e.g., succeeded_commands, succeeded_queries).
+                         Overrides of this method should return these stats when progress reporting is enabled.
 
         It also provides a way for invoking a user defined function to handle the
         responses of each of the queries executed. This function can be used to process
@@ -187,7 +191,8 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 worker_stats["objects_existed"] = sum(
                     [v['status'] == 2 for i in r for k, v in i.items()])
             elif result == 1:
-                self.error_counter += 1
+                with self._error_lock:
+                    self.error_counter += 1
                 worker_stats["succeeded_queries"] = 0
                 worker_stats["succeeded_commands"] = 0
                 worker_stats["objects_existed"] = 0
@@ -245,14 +250,18 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 logger.exception(e)
                 logger.warning(
                     f"Worker {thid} failed to execute batch {i}: [{batch_start},{batch_end}]")
-                self.error_counter += 1
+                with self._error_lock:
+                    self.error_counter += 1
 
             if self.stats:
                 self.pb.update(batch_end - batch_start)
 
+            with self._error_lock:
+                current_errors = self.error_counter
+
             if getattr(self, "log_progress", False):
                 logger.info(f"Worker {thid} completed batch {
-                            i + 1}/{total_batches}. Worker stats: {worker_stats}, Errors so far: {self.error_counter}")
+                            i + 1}/{total_batches}. Worker stats: {worker_stats}, Errors so far: {current_errors}")
 
             if hasattr(self, "progress_callback") and callable(self.progress_callback):
                 try:
@@ -263,7 +272,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
                         batch_start=batch_start,
                         batch_end=batch_end,
                         worker_stats=worker_stats,
-                        errors=self.error_counter
+                        errors=current_errors
                     )
                 except Exception as cb_e:
                     logger.warning(f"progress_callback failed: {cb_e}")

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -260,8 +260,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 current_errors = self.error_counter
 
             if getattr(self, "log_progress", False):
-                logger.info(f"Worker {thid} completed batch {
-                            i + 1}/{total_batches}. Worker stats: {worker_stats}, Errors so far: {current_errors}")
+                logger.info(f"Worker {thid} completed batch {i + 1}/{total_batches}. Worker stats: {dict(worker_stats)}, Errors so far: {current_errors}")
 
             if hasattr(self, "progress_callback") and callable(self.progress_callback):
                 try:
@@ -271,7 +270,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
                         total_batches=total_batches,
                         batch_start=batch_start,
                         batch_end=batch_end,
-                        worker_stats=worker_stats,
+                        worker_stats=dict(worker_stats),
                         errors=current_errors
                     )
                 except Exception as cb_e:

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -278,7 +278,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
                         errors=current_errors
                     )
                 except Exception as cb_e:
-                    logger.warning(f"progress_callback failed: {cb_e}")
+                    logger.exception(f"progress_callback failed: {cb_e}")
 
         logger.info(f"Worker {thid} executed {total_batches} batches")
 
@@ -312,6 +312,9 @@ class ParallelQuery(Parallelizer.Parallelizer):
         self.log_progress = kwargs.get("log_progress", False)
 
         use_dask = hasattr(generator, "use_dask") and generator.use_dask
+        if use_dask and (self.progress_callback or self.log_progress):
+            logger.warning("progress_callback and log_progress are not supported when using Dask.")
+
         if use_dask:
             self._reset(batchsize=batchsize, numthreads=numthreads)
             self.daskmanager = DaskManager(num_workers=numthreads)

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -260,8 +260,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 current_errors = self.error_counter
 
             if getattr(self, "log_progress", False):
-                logger.info(f"Worker {thid} completed batch {
-                            i + 1}/{total_batches}. Worker stats: {dict(worker_stats)}, Errors so far: {current_errors}")
+                logger.info(f"Worker {thid} completed batch {i + 1}/{total_batches}. Worker stats: {dict(worker_stats)}, Errors so far: {current_errors}")
 
             if hasattr(self, "progress_callback") and callable(self.progress_callback):
                 try:

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -124,6 +124,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
 
         Args:
             client (Connector): The database connector.
+            batch_start (int): The starting index of the batch.
             data (list[tuple[Commands, Blobs]]): The data to be batched.  Each tuple contains a list of commands and a list of blobs.
 
         Returns:
@@ -317,6 +318,8 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 "progress_callback and log_progress are not supported when using Dask.")
 
         if use_dask:
+            if self.progress_callback or self.log_progress:
+                logger.warning("progress_callback and log_progress are not supported when using Dask.")
             self._reset(batchsize=batchsize, numthreads=numthreads)
             self.daskmanager = DaskManager(num_workers=numthreads)
 

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -306,6 +306,14 @@ class ParallelQuery(Parallelizer.Parallelizer):
             stats (bool, optional): Show statistics at end of ingestion. Defaults to False.
             **kwargs: Additional arguments, such as:
                 progress_callback (callable): A function called after each batch completes.
+                    It must accept the following keyword arguments:
+                    - worker_id (int): The ID of the worker.
+                    - batch_index (int): The 0-based index of the batch for this worker.
+                    - total_batches (int): Total number of batches for this worker.
+                    - batch_start (int): The starting index of the batch.
+                    - batch_end (int): The ending index of the batch.
+                    - worker_stats (dict): The stats for this batch.
+                    - errors (int): The total number of errors encountered so far by all workers.
                 log_progress (bool): If True, logs progress per batch via the logger.
         """
 

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -319,7 +319,8 @@ class ParallelQuery(Parallelizer.Parallelizer):
 
         if use_dask:
             if self.progress_callback or self.log_progress:
-                logger.warning("progress_callback and log_progress are not supported when using Dask.")
+                logger.warning(
+                    "progress_callback and log_progress are not supported when using Dask.")
             self._reset(batchsize=batchsize, numthreads=numthreads)
             self.daskmanager = DaskManager(num_workers=numthreads)
 

--- a/aperturedb/ParallelQuerySet.py
+++ b/aperturedb/ParallelQuerySet.py
@@ -379,7 +379,7 @@ class ParallelQuerySet(ParallelQuery):
 
         Args:
             client (Connector): The ApertureDB Connector
-            data (List[Tuple[Query, Blobs]]): A list of tuples, each containing a list of commands and a list of blobs
+            data (List[Tuple[Commands, Blobs]]): A list of tuples, each containing a list of commands and a list of blobs
 
         Returns:
             dict | None: The per-batch worker stats (e.g., succeeded_commands, succeeded_queries).

--- a/aperturedb/ParallelQuerySet.py
+++ b/aperturedb/ParallelQuerySet.py
@@ -371,7 +371,7 @@ class ParallelQuerySet(ParallelQuery):
         logger.error(type(generator[0]))
         return False
 
-    def do_batch(self, client: Connector, batch_start: int,  data: List[Tuple[Commands, Blobs]]) -> None:
+    def do_batch(self, client: Connector, batch_start: int,  data: List[Tuple[Commands, Blobs]]) -> dict | None:
         """
         This is an override of ParallelQuery.do_batch.
 
@@ -380,6 +380,9 @@ class ParallelQuerySet(ParallelQuery):
         Args:
             client (Connector): The ApertureDB Connector
             data (List[Tuple[Query, Blobs]]): A list of tuples, each containing a list of commands and a list of blobs
+
+        Returns:
+            dict | None: The per-batch worker stats (e.g., succeeded_commands, succeeded_queries).
         """
         if not hasattr(self.generator, "commands_per_query"):
             raise Exception(
@@ -393,7 +396,7 @@ class ParallelQuerySet(ParallelQuery):
         self.batch_command = gen_execute_batch_sets(
             self.base_batch_command)
 
-        ParallelQuery.do_batch(self, client, batch_start, data)
+        return ParallelQuery.do_batch(self, client, batch_start, data)
 
     def print_stats(self) -> None:
 

--- a/aperturedb/ParallelQuerySet.py
+++ b/aperturedb/ParallelQuerySet.py
@@ -379,6 +379,7 @@ class ParallelQuerySet(ParallelQuery):
 
         Args:
             client (Connector): The ApertureDB Connector
+            batch_start (int): The starting index of the batch.
             data (List[Tuple[Commands, Blobs]]): A list of tuples, each containing a list of commands and a list of blobs
 
         Returns:

--- a/aperturedb/Parallelizer.py
+++ b/aperturedb/Parallelizer.py
@@ -41,6 +41,7 @@ class Parallelizer:
         self.times_arr = []
         self.total_actions_time = 0
         self.error_counter = 0
+        self._error_lock = threading.Lock()
         self.actual_stats = []
 
     def get_times(self):

--- a/test/test_Parallel.py
+++ b/test/test_Parallel.py
@@ -119,20 +119,31 @@ class TestParallel():
                               progress_callback=my_callback,
                               log_progress=True)
 
-            assert len(callback_calls) > 0
+            import math
+            elements_per_thread = math.ceil(elements / numthreads)
+            expected_batches_per_thread = elements_per_thread // batchsize + (1 if elements_per_thread % batchsize > 0 else 0)
+            expected_total_calls = expected_batches_per_thread * numthreads
+
+            assert len(callback_calls) == expected_total_calls
 
             for call in callback_calls:
                 assert "worker_id" in call
                 assert "total_batches" in call
+                assert call["total_batches"] == expected_batches_per_thread
                 assert "batch_start" in call
                 assert "batch_end" in call
+                # Check that batch limits align with batch_index
+                expected_start = (call["worker_id"] * elements_per_thread) + call["batch_index"] * batchsize
+                assert call["batch_start"] == expected_start
+                expected_end = min(expected_start + batchsize, (call["worker_id"] + 1) * elements_per_thread)
+                assert call["batch_end"] == expected_end
                 assert "worker_stats" in call
                 assert "errors" in call
 
             log_messages = [record.message for record in caplog.records]
             completed_logs = [
                 msg for msg in log_messages if "completed batch" in msg]
-            assert len(completed_logs) > 0
+            assert len(completed_logs) == expected_total_calls
 
         except Exception as e:
             print(e)

--- a/test/test_Parallel.py
+++ b/test/test_Parallel.py
@@ -97,9 +97,9 @@ class TestParallel():
 
             generator = GeneratorWithErrors(elements=elements, error_pct=0)
             querier = ParallelQuery(db, dry_run=True)
-            
+
             callback_calls = []
-            
+
             def my_callback(worker_id, batch_index, total_batches, batch_start, batch_end, worker_stats, errors):
                 callback_calls.append({
                     "worker_id": worker_id,
@@ -118,9 +118,9 @@ class TestParallel():
                               stats=True,
                               progress_callback=my_callback,
                               log_progress=True)
-                
+
             assert len(callback_calls) > 0
-            
+
             for call in callback_calls:
                 assert "worker_id" in call
                 assert "total_batches" in call
@@ -128,11 +128,12 @@ class TestParallel():
                 assert "batch_end" in call
                 assert "worker_stats" in call
                 assert "errors" in call
-            
+
             log_messages = [record.message for record in caplog.records]
-            completed_logs = [msg for msg in log_messages if "completed batch" in msg]
+            completed_logs = [
+                msg for msg in log_messages if "completed batch" in msg]
             assert len(completed_logs) > 0
-            
+
         except Exception as e:
             print(e)
             assert False

--- a/test/test_Parallel.py
+++ b/test/test_Parallel.py
@@ -143,7 +143,7 @@ class TestParallel():
                 assert "worker_stats" in call
                 assert "errors" in call
 
-            log_messages = [record.message for record in caplog.records]
+            log_messages = [record.getMessage() for record in caplog.records]
             completed_logs = [
                 msg for msg in log_messages if "completed batch" in msg]
             assert len(completed_logs) == expected_total_calls

--- a/test/test_Parallel.py
+++ b/test/test_Parallel.py
@@ -121,7 +121,8 @@ class TestParallel():
 
             import math
             elements_per_thread = math.ceil(elements / numthreads)
-            expected_batches_per_thread = elements_per_thread // batchsize + (1 if elements_per_thread % batchsize > 0 else 0)
+            expected_batches_per_thread = elements_per_thread // batchsize + \
+                (1 if elements_per_thread % batchsize > 0 else 0)
             expected_total_calls = expected_batches_per_thread * numthreads
 
             assert len(callback_calls) == expected_total_calls
@@ -133,9 +134,11 @@ class TestParallel():
                 assert "batch_start" in call
                 assert "batch_end" in call
                 # Check that batch limits align with batch_index
-                expected_start = (call["worker_id"] * elements_per_thread) + call["batch_index"] * batchsize
+                expected_start = (
+                    call["worker_id"] * elements_per_thread) + call["batch_index"] * batchsize
                 assert call["batch_start"] == expected_start
-                expected_end = min(expected_start + batchsize, (call["worker_id"] + 1) * elements_per_thread)
+                expected_end = min(expected_start + batchsize,
+                                   (call["worker_id"] + 1) * elements_per_thread)
                 assert call["batch_end"] == expected_end
                 assert "worker_stats" in call
                 assert "errors" in call

--- a/test/test_Parallel.py
+++ b/test/test_Parallel.py
@@ -81,3 +81,58 @@ class TestParallel():
             print(e)
             print("Failed to renew Session")
             assert False
+
+    def test_progress_callback_and_log(self, caplog):
+        """
+        Verifies that progress_callback is called and log_progress logs appropriately.
+        """
+        from unittest.mock import MagicMock
+        db = MagicMock()
+        db.query.return_value = ([{"GetSchema": {}}], [])
+        db.clone.return_value = db
+        try:
+            elements = 10
+            batchsize = 2
+            numthreads = 2
+
+            generator = GeneratorWithErrors(elements=elements, error_pct=0)
+            querier = ParallelQuery(db, dry_run=True)
+            
+            callback_calls = []
+            
+            def my_callback(worker_id, batch_index, total_batches, batch_start, batch_end, worker_stats, errors):
+                callback_calls.append({
+                    "worker_id": worker_id,
+                    "batch_index": batch_index,
+                    "total_batches": total_batches,
+                    "batch_start": batch_start,
+                    "batch_end": batch_end,
+                    "worker_stats": worker_stats,
+                    "errors": errors
+                })
+
+            import logging
+            with caplog.at_level(logging.INFO):
+                querier.query(generator, batchsize=batchsize,
+                              numthreads=numthreads,
+                              stats=True,
+                              progress_callback=my_callback,
+                              log_progress=True)
+                
+            assert len(callback_calls) > 0
+            
+            for call in callback_calls:
+                assert "worker_id" in call
+                assert "total_batches" in call
+                assert "batch_start" in call
+                assert "batch_end" in call
+                assert "worker_stats" in call
+                assert "errors" in call
+            
+            log_messages = [record.message for record in caplog.records]
+            completed_logs = [msg for msg in log_messages if "completed batch" in msg]
+            assert len(completed_logs) > 0
+            
+        except Exception as e:
+            print(e)
+            assert False


### PR DESCRIPTION
### Summary
This PR exposes detailed stats and progress during long running tasks like ingestion in `ParallelLoader`. 

Users can now pass `progress_callback` to receive realtime worker batch completion events with stats, or `log_progress=True` to log progress automatically via `logger.info`.

### Verification
Manually tested with a test script verifying that the callback is properly invoked after every batch completion with updated `worker_stats` and `errors` fields.

Fixes #231