### PR TITLE
fix: resolve unhashable type slice in ParallelQuery

### DIFF
--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -355,7 +355,7 @@ def map_response_to_handler(handler, query, query_blobs,  response, response_blo
         blobs_end = blobs_start + blobs_per_query
 
         b_count = 0
-        if issubclass(type(response), list):
+        if isinstance(response, list):
             for req, resp in zip(query[start:end], response[start:end]):
                 for k in req:
                     blob_returning_commands = ["FindImage", "FindBlob", "FindVideo",
@@ -369,8 +369,8 @@ def map_response_to_handler(handler, query, query_blobs,  response, response_blo
         handler(
             query[start:end],
             query_blobs[blobs_start:blobs_end],
-            response[start:end] if issubclass(
-                type(response), list) else response,
+            response[start:end] if isinstance(
+                response, list) else response,
             response_blobs[blobs_returned:blobs_returned + b_count] if
             len(response_blobs) >= blobs_returned + b_count else None,
             None if cmd_index_offset is None else cmd_index_offset + i)

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -375,8 +375,7 @@ def map_response_to_handler(handler, query, query_blobs,  response, response_blo
         handler(
             query[start:end],
             query_blobs[blobs_start:blobs_end],
-            response[start:end] if isinstance(
-                response, list) else response,
+            response[start:end] if is_list else response,
             response_blobs[blobs_returned:blobs_returned + b_count] if
             len(response_blobs) >= blobs_returned + b_count else None,
             None if cmd_index_offset is None else cmd_index_offset + i)

--- a/aperturedb/ParallelLoader.py
+++ b/aperturedb/ParallelLoader.py
@@ -203,10 +203,10 @@ class ParallelLoader(ParallelQuery.ParallelQuery):
         print(f"Total time (s): {self.total_actions_time}")
         print(f"Total queries executed: {total_queries_exec}")
 
-        succeeded_queries = sum([stat["succeeded_queries"]
-                                for stat in self.actual_stats])
-        succeeded_commands = sum([stat["succeeded_commands"]
-                                  for stat in self.actual_stats])
+        succeeded_queries = sum(stat["succeeded_queries"]
+                                for stat in self.actual_stats)
+        succeeded_commands = sum(stat["succeeded_commands"]
+                                 for stat in self.actual_stats)
 
         if succeeded_queries == 0:
             print("All queries failed!")

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -167,6 +167,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
                                     f"expected 6 > args > 3, got {parameter_count}")
                 if parameter_count == 4:
                     indexless_handler = response_handler
+
                     def response_handler(query, qblobs, resp, rblobs, qindex): return indexless_handler(
                         query, qblobs, resp, rblobs)
 

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -193,20 +193,24 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 worker_stats["objects_existed"] = 0
             elif result == 2:
                 # with result 2, some queries might have failed.
-                def filter_per_group(group):
-                    return group.items() if isinstance(group, dict) else {}
-                worker_stats["succeeded_commands"] = sum(
-                    [v['status'] == 0 for i in r for k, v in filter_per_group(i)])
-                worker_stats["objects_existed"] = sum(
-                    [v['status'] == 2 for i in r for k, v in filter_per_group(i)])
-                sq = 0
-                for i in range(0, len(r), self.commands_per_query):
-                    # Some errors stop the whole query from being executed
-                    # https://docs.aperturedata.io/query_language/Overview/Responses#return-status
-                    if issubclass(type(r), list):
+                if isinstance(r, list):
+                    def filter_per_group(group):
+                        return group.items() if isinstance(group, dict) else {}
+                    worker_stats["succeeded_commands"] = sum(
+                        [v['status'] == 0 for i in r for k, v in filter_per_group(i)])
+                    worker_stats["objects_existed"] = sum(
+                        [v['status'] == 2 for i in r for k, v in filter_per_group(i)])
+                    sq = 0
+                    for i in range(0, len(r), self.commands_per_query):
+                        # Some errors stop the whole query from being executed
+                        # https://docs.aperturedata.io/query_language/Overview/Responses#return-status
                         if all([v['status'] == 0 for j in r[i:i + self.commands_per_query] for k, v in filter_per_group(j)]):
                             sq += 1
-                worker_stats["succeeded_queries"] = sq
+                    worker_stats["succeeded_queries"] = sq
+                else:
+                    worker_stats["succeeded_commands"] = 0
+                    worker_stats["objects_existed"] = 0
+                    worker_stats["succeeded_queries"] = 0
         else:
             query_time = 1
             worker_stats["succeeded_commands"] = len(q)
@@ -296,7 +300,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 self.print_stats()
         else:
             # allow subclass to do verification
-            if issubclass(type(self), ParallelQuery) and hasattr(self, 'verify_generator') and callable(self.verify_generator):
+            if isinstance(self, ParallelQuery) and hasattr(self, 'verify_generator') and callable(self.verify_generator):
                 self.verify_generator(generator)
             elif len(generator) > 0:
                 if isinstance(generator[0], tuple) and isinstance(generator[0][0], list):

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -204,16 +204,16 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 # with result 2, some queries might have failed.
                 if isinstance(r, list):
                     def filter_per_group(group):
-                        return group.items() if isinstance(group, dict) else {}.items()
+                        return group.items() if isinstance(group, dict) else ()
                     worker_stats["succeeded_commands"] = sum(
-                        [v['status'] == 0 for i in r for k, v in filter_per_group(i)])
+                        v['status'] == 0 for i in r for k, v in filter_per_group(i))
                     worker_stats["objects_existed"] = sum(
-                        [v['status'] == 2 for i in r for k, v in filter_per_group(i)])
+                        v['status'] == 2 for i in r for k, v in filter_per_group(i))
                     sq = 0
                     for i in range(0, len(r), self.commands_per_query):
                         # Some errors stop the whole query from being executed
                         # https://docs.aperturedata.io/query_language/Overview/Responses#return-status
-                        if all([v['status'] == 0 for j in r[i:i + self.commands_per_query] for k, v in filter_per_group(j)]):
+                        if all(v['status'] == 0 for j in r[i:i + self.commands_per_query] for k, v in filter_per_group(j)):
                             sq += 1
                     worker_stats["succeeded_queries"] = sq
                 else:
@@ -261,16 +261,16 @@ class ParallelQuery(Parallelizer.Parallelizer):
         logger.info(f"Worker {thid} executed {total_batches} batches")
 
     def get_objects_existed(self) -> int:
-        return sum([stat["objects_existed"]
-                    for stat in self.actual_stats])
+        return sum(stat["objects_existed"]
+                   for stat in self.actual_stats)
 
     def get_succeeded_queries(self) -> int:
-        return sum([stat["succeeded_queries"]
-                    for stat in self.actual_stats])
+        return sum(stat["succeeded_queries"]
+                   for stat in self.actual_stats)
 
     def get_succeeded_commands(self) -> int:
-        return sum([stat["succeeded_commands"]
-                    for stat in self.actual_stats])
+        return sum(stat["succeeded_commands"]
+                   for stat in self.actual_stats)
 
     def query(self, generator, batchsize: int = 1, numthreads: int = 4, stats: bool = False) -> None:
         """

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -193,6 +193,8 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 worker_stats["succeeded_commands"] = 0
                 worker_stats["objects_existed"] = 0
             elif result == 2:
+                if client.last_query_ok():
+                    query_time = client.get_last_query_time()
                 # with result 2, some queries might have failed.
                 if isinstance(r, list):
                     def filter_per_group(group):

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -204,7 +204,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 # with result 2, some queries might have failed.
                 if isinstance(r, list):
                     def filter_per_group(group):
-                        return group.items() if isinstance(group, dict) else {}
+                        return group.items() if isinstance(group, dict) else {}.items()
                     worker_stats["succeeded_commands"] = sum(
                         [v['status'] == 0 for i in r for k, v in filter_per_group(i)])
                     worker_stats["objects_existed"] = sum(

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -192,7 +192,7 @@ class ParallelQuery(Parallelizer.Parallelizer):
                 worker_stats["succeeded_commands"] = len(q)
                 worker_stats["succeeded_queries"] = len(data)
                 worker_stats["objects_existed"] = sum(
-                    [v['status'] == 2 for i in r for k, v in i.items()])
+                    v['status'] == 2 for i in r for k, v in i.items())
             elif result == 1:
                 self.error_counter += 1
                 worker_stats["succeeded_queries"] = 0

--- a/test/test_Parallel.py
+++ b/test/test_Parallel.py
@@ -81,3 +81,34 @@ class TestParallel():
             print(e)
             print("Failed to renew Session")
             assert False
+
+    def test_dictResponseHandling(self):
+        """
+        Verifies that it handles a dict response from a failing server properly.
+        Guards against regression to "unhashable type: 'slice'" when r is a dict.
+        """
+        from unittest.mock import patch, MagicMock
+        try:
+            elements = 10
+            generator = GeneratorWithErrors(elements=elements)
+            db = MagicMock(spec=Connector)
+            db.clone.return_value = db
+            db.config = "mock_config"
+            db.query.return_value = ([{"GetSchema": {"status": 0}}], [])
+            querier = ParallelQuery(db, dry_run=False)
+            
+            # Now set the mock for the actual queries
+            db.query.return_value = ({"status": 3, "error_msg": "mock error"}, [])
+            db.last_query_ok.return_value = True
+            db.get_last_query_time.return_value = 1.0
+            
+            querier.query(generator, batchsize=2, numthreads=1, stats=True)
+            
+            # Since all queries got status 3, no commands or queries succeeded.
+            assert querier.get_succeeded_commands() == 0
+            assert querier.get_succeeded_queries() == 0
+            # Ensure stats were recorded properly
+            assert len(querier.actual_stats) > 0
+        except Exception as e:
+            print(e)
+            assert False

--- a/test/test_Parallel.py
+++ b/test/test_Parallel.py
@@ -96,14 +96,15 @@ class TestParallel():
             db.config = "mock_config"
             db.query.return_value = ([{"GetSchema": {"status": 0}}], [])
             querier = ParallelQuery(db, dry_run=False)
-            
+
             # Now set the mock for the actual queries
-            db.query.return_value = ({"status": 3, "error_msg": "mock error"}, [])
+            db.query.return_value = (
+                {"status": 3, "error_msg": "mock error"}, [])
             db.last_query_ok.return_value = True
             db.get_last_query_time.return_value = 1.0
-            
+
             querier.query(generator, batchsize=2, numthreads=1, stats=True)
-            
+
             # Since all queries got status 3, no commands or queries succeeded.
             assert querier.get_succeeded_commands() == 0
             assert querier.get_succeeded_queries() == 0

--- a/test/test_Parallel.py
+++ b/test/test_Parallel.py
@@ -87,7 +87,7 @@ class TestParallel():
         Verifies that it handles a dict response from a failing server properly.
         Guards against regression to "unhashable type: 'slice'" when r is a dict.
         """
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import MagicMock
         try:
             elements = 10
             generator = GeneratorWithErrors(elements=elements)

--- a/test/test_Parallel.py
+++ b/test/test_Parallel.py
@@ -62,7 +62,7 @@ class TestParallel():
         except Exception as e:
             print(e)
             print("Failed to renew Session")
-            assert False
+            raise
 
     def test_allBadQueries(self, db: Connector):
         """
@@ -80,7 +80,7 @@ class TestParallel():
         except Exception as e:
             print(e)
             print("Failed to renew Session")
-            assert False
+            raise
 
     def test_dictResponseHandling(self):
         """
@@ -112,7 +112,7 @@ class TestParallel():
             assert len(querier.actual_stats) > 0
         except Exception as e:
             print(e)
-            assert False
+            raise
 
 
 def test_dask_dry_run(db: Connector):


### PR DESCRIPTION
## Summary
This PR resolves an issue in ParallelQuery where the database returns a dictionary response rather than a list of responses under certain failure conditions, resulting in a `TypeError: unhashable type: 'slice'`. 

## Verification
- Modified `ParallelQuery.do_batch` to properly check `isinstance(r, list)` to prevent incorrect indexing or iterating over a dictionary response as if it were a list.
- Replaced non-idiomatic `issubclass(type(x), y)` checks with `isinstance(x, y)` throughout `ParallelQuery.py` and `CommonLibrary.py` for clarity and correctness.
- Ran tests via `pytest test/` to ensure existing behavior is preserved.

Fixes aperture-data/aperturedb-python#358