### PR TITLE
Fix duplicate width and height properties for images

### DIFF
--- a/aperturedb/transformers/image_properties.py
+++ b/aperturedb/transformers/image_properties.py
@@ -41,6 +41,12 @@ class ImageProperties(Transformer):
                 src_properties["adb_image_id"] = str(
                     src_properties["id"] if "id" in src_properties else uuid.uuid4().hex)
 
+                # Remove duplicate width/height if present to avoid confusion
+                if "width" in src_properties:
+                    del src_properties["width"]
+                if "height" in src_properties:
+                    del src_properties["height"]
+
         except Exception as e:
             # Importantly, do not raise an exception here, since it will kill ingestion.
             # Create a log message instead, for post-mortem analysis.

--- a/test/test_ImageProperties.py
+++ b/test/test_ImageProperties.py
@@ -5,13 +5,17 @@ from aperturedb.Subscriptable import Subscriptable
 import io
 from PIL import Image
 
+
 class DummyData(Subscriptable):
     def __init__(self, transactions):
         self.transactions = transactions
+
     def __len__(self):
         return len(self.transactions)
+
     def getitem(self, idx):
         return self.transactions[idx]
+
 
 class TestImageProperties(unittest.TestCase):
     @patch('aperturedb.transformers.transformer.Transformer.get_utils')
@@ -34,19 +38,19 @@ class TestImageProperties(unittest.TestCase):
                 [img_data]
             )
         ]
-        
+
         dummy_data = DummyData(transactions)
-        
+
         # Instantiate the transformer
         transformer = ImageProperties(dummy_data)
         # Manually set the indices that would normally be set by Transformer base class
         transformer._add_image_index = [0]
-        
+
         # Run transformation
         result = transformer[0]
-        
+
         props = result[0][0]["AddImage"]["properties"]
-        
+
         # Check expected behavior
         self.assertNotIn("width", props)
         self.assertNotIn("height", props)
@@ -55,6 +59,7 @@ class TestImageProperties(unittest.TestCase):
         self.assertEqual(props["adb_image_id"], "test_id")
         self.assertIn("adb_image_size", props)
         self.assertIn("adb_image_sha256", props)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_ImageProperties.py
+++ b/test/test_ImageProperties.py
@@ -1,0 +1,60 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from aperturedb.transformers.image_properties import ImageProperties
+from aperturedb.Subscriptable import Subscriptable
+import io
+from PIL import Image
+
+class DummyData(Subscriptable):
+    def __init__(self, transactions):
+        self.transactions = transactions
+    def __len__(self):
+        return len(self.transactions)
+    def getitem(self, idx):
+        return self.transactions[idx]
+
+class TestImageProperties(unittest.TestCase):
+    @patch('aperturedb.transformers.transformer.Transformer.get_utils')
+    def test_image_properties_removes_width_height(self, mock_get_utils):
+        # Mock get_utils behavior
+        mock_utils = MagicMock()
+        mock_utils.get_indexed_props.return_value = ["adb_data_source"]
+        mock_get_utils.return_value = mock_utils
+
+        # Create a tiny valid image (10x20)
+        img = Image.new('RGB', (10, 20), color='red')
+        img_bytes = io.BytesIO()
+        img.save(img_bytes, format='JPEG')
+        img_data = img_bytes.getvalue()
+
+        # Mock transaction with existing width and height
+        transactions = [
+            (
+                [{"AddImage": {"properties": {"width": 100, "height": 200, "id": "test_id"}}}],
+                [img_data]
+            )
+        ]
+        
+        dummy_data = DummyData(transactions)
+        
+        # Instantiate the transformer
+        transformer = ImageProperties(dummy_data)
+        # Manually set the indices that would normally be set by Transformer base class
+        transformer._add_image_index = [0]
+        
+        # Run transformation
+        result = transformer[0]
+        
+        props = result[0][0]["AddImage"]["properties"]
+        
+        # Check expected behavior
+        self.assertNotIn("width", props)
+        self.assertNotIn("height", props)
+        self.assertEqual(props["adb_image_width"], 10)
+        self.assertEqual(props["adb_image_height"], 20)
+        self.assertEqual(props["adb_image_id"], "test_id")
+        self.assertIn("adb_image_size", props)
+        self.assertIn("adb_image_sha256", props)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_ImageProperties.py
+++ b/test/test_ImageProperties.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest.mock import MagicMock, patch
 from aperturedb.transformers.image_properties import ImageProperties
 from aperturedb.Subscriptable import Subscriptable
@@ -17,49 +16,42 @@ class DummyData(Subscriptable):
         return self.transactions[idx]
 
 
-class TestImageProperties(unittest.TestCase):
-    @patch('aperturedb.transformers.transformer.Transformer.get_utils')
-    def test_image_properties_removes_width_height(self, mock_get_utils):
-        # Mock get_utils behavior
-        mock_utils = MagicMock()
-        mock_utils.get_indexed_props.return_value = ["adb_data_source"]
-        mock_get_utils.return_value = mock_utils
+@patch('aperturedb.transformers.transformer.Transformer.get_utils')
+def test_image_properties_removes_width_height(mock_get_utils):
+    # Mock get_utils behavior
+    mock_utils = MagicMock()
+    mock_utils.get_indexed_props.return_value = ["adb_data_source"]
+    mock_get_utils.return_value = mock_utils
 
-        # Create a tiny valid image (10x20)
-        img = Image.new('RGB', (10, 20), color='red')
-        img_bytes = io.BytesIO()
-        img.save(img_bytes, format='JPEG')
-        img_data = img_bytes.getvalue()
+    # Create a tiny valid image (10x20)
+    img = Image.new('RGB', (10, 20), color='red')
+    img_bytes = io.BytesIO()
+    img.save(img_bytes, format='JPEG')
+    img_data = img_bytes.getvalue()
 
-        # Mock transaction with existing width and height
-        transactions = [
-            (
-                [{"AddImage": {"properties": {"width": 100, "height": 200, "id": "test_id"}}}],
-                [img_data]
-            )
-        ]
+    # Mock transaction with existing width and height
+    transactions = [
+        (
+            [{"AddImage": {"properties": {"width": 100, "height": 200, "id": "test_id"}}}],
+            [img_data]
+        )
+    ]
 
-        dummy_data = DummyData(transactions)
+    dummy_data = DummyData(transactions)
 
-        # Instantiate the transformer
-        transformer = ImageProperties(dummy_data)
-        # Manually set the indices that would normally be set by Transformer base class
-        transformer._add_image_index = [0]
+    # Instantiate the transformer
+    transformer = ImageProperties(dummy_data)
 
-        # Run transformation
-        result = transformer[0]
+    # Run transformation
+    result = transformer[0]
 
-        props = result[0][0]["AddImage"]["properties"]
+    props = result[0][0]["AddImage"]["properties"]
 
-        # Check expected behavior
-        self.assertNotIn("width", props)
-        self.assertNotIn("height", props)
-        self.assertEqual(props["adb_image_width"], 10)
-        self.assertEqual(props["adb_image_height"], 20)
-        self.assertEqual(props["adb_image_id"], "test_id")
-        self.assertIn("adb_image_size", props)
-        self.assertIn("adb_image_sha256", props)
-
-
-if __name__ == '__main__':
-    unittest.main()
+    # Check expected behavior
+    assert "width" not in props
+    assert "height" not in props
+    assert props["adb_image_width"] == 10
+    assert props["adb_image_height"] == 20
+    assert props["adb_image_id"] == "test_id"
+    assert "adb_image_size" in props
+    assert "adb_image_sha256" in props


### PR DESCRIPTION
## Summary
Removes `width` and `height` properties if they are present when running the `ImageProperties` transformer. Since the transformer already introduces `adb_image_width` and `adb_image_height`, this avoids duplication and confusion (e.g. for COCO image annotations).

## Verification
Locally verified that if `width` and `height` are present in `src_properties` before the transformer runs, they are successfully removed, while `adb_image_width` and `adb_image_height` are properly set from the image dimensions.

Fixes aperture-data/aperturedb-python#331.