### PR TITLE
Fix: Prevent rich from swallowing Configuration objects in CLI output

### DIFF
--- a/aperturedb/Configuration.py
+++ b/aperturedb/Configuration.py
@@ -57,7 +57,7 @@ class Configuration:
     def __repr__(self) -> str:
         mode = "REST" if self.use_rest else "TCP"
         auth_mode = self.auth_mode()
-        return f"[{self.host}:{self.port} as {self.username} using {mode} with SSL={self.__ssl_mode()} auth={auth_mode}]"
+        return f"<{self.host}:{self.port} as {self.username} using {mode} with SSL={self.__ssl_mode()} auth={auth_mode}>"
 
     def deflate(self) -> list:
         return self.create_aperturedb_key(self.host, self.port, self.token,

--- a/test/test_Configuration.py
+++ b/test/test_Configuration.py
@@ -1,5 +1,6 @@
 from aperturedb.Configuration import Configuration
 
+
 def test_configuration_repr():
     c = Configuration(
         host="localhost",

--- a/test/test_Configuration.py
+++ b/test/test_Configuration.py
@@ -1,0 +1,22 @@
+from aperturedb.Configuration import Configuration
+
+def test_configuration_repr():
+    c = Configuration(
+        host="localhost",
+        port=55555,
+        username="admin",
+        password="password",
+        name="test_config",
+        use_ssl=True,
+        use_rest=False,
+    )
+    r = repr(c)
+    assert r.startswith("<")
+    assert r.endswith(">")
+    assert "[" not in r
+    assert "]" not in r
+    assert "localhost:55555" in r
+    assert "as admin" in r
+    assert "using TCP" in r
+    assert "auth=password" in r
+    assert "SSL=" in r


### PR DESCRIPTION
## Summary
Replaces square brackets with angle brackets in `Configuration.__repr__`.

## Verification
Fixes a bug where `adb config ls` in Google Colab (and other environments with wide or unconstrained terminal widths) printed blank lines. The issue occurred because `rich.console.Console` parses strings wrapped in `[` and `]` as markup tags. When the repr of the configuration object was embedded within dictionary output by `console.log`, the entire configuration string was treated as an unclosed/invalid styling tag and subsequently swallowed without error.

By matching standard Python representation semantics (using `<` and `>`), we avoid clashes with `rich`'s markdown engine. 

Fixes aperture-data/aperturedb-python#461.