### PR TITLE
feat: add support for Tensorflow dataset

### DIFF
--- a/aperturedb/PyTorchDataset.py
+++ b/aperturedb/PyTorchDataset.py
@@ -141,7 +141,12 @@ class ApertureDBDataset(data.Dataset):
                 try:
                     self.batch_labels = [l[self.label_prop] for l in entities]
                 except KeyError:
-                    logger.error(f"Property '{self.label_prop}' not found in some entities. Ensure all entities have this property.")
+                    prop = self.label_prop
+                    msg = (
+                        f"Property '{prop}' not found in some entities. "
+                        "Ensure all entities have this property."
+                    )
+                    logger.error(msg)
                     raise
             else:
                 self.batch_labels = ["none" for l in range(len(b))]

--- a/aperturedb/PyTorchDataset.py
+++ b/aperturedb/PyTorchDataset.py
@@ -46,6 +46,13 @@ class ApertureDBDataset(data.Dataset):
         if not "results" in self.query[self.find_image_idx]["FindImage"]:
             self.query[self.find_image_idx]["FindImage"]["results"] = {}
 
+        if self.label_prop is not None:
+            results = self.query[self.find_image_idx]["FindImage"]["results"]
+            if "list" not in results:
+                results["list"] = []
+            if self.label_prop not in results["list"]:
+                results["list"].append(self.label_prop)
+
         self.query[self.find_image_idx]["FindImage"]["batch"] = {}
         self.query[self.find_image_idx]["FindImage"]["blobs"] = True
 
@@ -131,7 +138,11 @@ class ApertureDBDataset(data.Dataset):
 
             if self.label_prop:
                 entities = r[self.find_image_idx]["FindImage"]["entities"]
-                self.batch_labels = [l[self.label_prop] for l in entities]
+                try:
+                    self.batch_labels = [l[self.label_prop] for l in entities]
+                except KeyError:
+                    logger.error(f"Property '{self.label_prop}' not found in some entities. Ensure all entities have this property.")
+                    raise
             else:
                 self.batch_labels = ["none" for l in range(len(b))]
         except:

--- a/aperturedb/TensorFlowDataset.py
+++ b/aperturedb/TensorFlowDataset.py
@@ -117,7 +117,12 @@ class ApertureDBTensorFlowDataset:
                 try:
                     self.batch_labels = [l[self.label_prop] for l in entities]
                 except KeyError:
-                    logger.error(f"Property '{self.label_prop}' not found in some entities. Ensure all entities have this property.")
+                    prop = self.label_prop
+                    msg = (
+                        f"Property '{prop}' not found in some entities. "
+                        "Ensure all entities have this property."
+                    )
+                    logger.error(msg)
                     raise
             else:
                 self.batch_labels = ["none" for l in range(len(b))]

--- a/aperturedb/TensorFlowDataset.py
+++ b/aperturedb/TensorFlowDataset.py
@@ -8,6 +8,7 @@ from aperturedb.Connector import Connector
 
 logger = logging.getLogger(__name__)
 
+
 class ApertureDBTensorFlowDataset:
     """
     This class implements a TensorFlow Dataset for ApertureDB.

--- a/aperturedb/TensorFlowDataset.py
+++ b/aperturedb/TensorFlowDataset.py
@@ -1,0 +1,152 @@
+import math
+import numpy as np
+import cv2
+import logging
+
+from aperturedb.CommonLibrary import execute_query
+from aperturedb.Connector import Connector
+
+logger = logging.getLogger(__name__)
+
+class ApertureDBTensorFlowDataset:
+    """
+    This class implements a TensorFlow Dataset for ApertureDB.
+    It is used to load images from ApertureDB into a TensorFlow model.
+    It can be initialized with a query that will be used to retrieve
+    the images from ApertureDB.
+    """
+
+    def __init__(self, client: Connector, query, label_prop=None, batch_size=1):
+
+        self.client = client.clone()
+        self.query = query
+        self.find_image_idx = None
+        self.total_elements = 0
+        self.batch_size     = batch_size
+        self.batch_images   = []
+        self.batch_start    = 0
+        self.batch_end      = 0
+        self.label_prop     = label_prop
+        self.label_type     = None
+
+        for i in range(len(query)):
+
+            name = list(query[i].keys())[0]
+            if name == "FindImage":
+                self.find_image_idx = i
+
+        if self.find_image_idx is None:
+            logger.error(
+                "Query error. The query must contain one FindImage command")
+            raise Exception('Query Error')
+
+        if not "results" in self.query[self.find_image_idx]["FindImage"]:
+            self.query[self.find_image_idx]["FindImage"]["results"] = {}
+
+        self.query[self.find_image_idx]["FindImage"]["batch"] = {}
+        self.query[self.find_image_idx]["FindImage"]["blobs"] = True
+
+        try:
+            _, r, b = execute_query(
+                client=self.client, query=self.query, blobs=[])
+            batch = r[self.find_image_idx]["FindImage"]["batch"]
+            self.total_elements = batch["total_elements"]
+        except:
+            logger.error(
+                f"Query error: {self.query} {self.client.get_last_response_str()}")
+            raise
+
+    def is_in_range(self, index):
+
+        if index >= self.batch_start and index < self.batch_end:
+            return True
+
+        return False
+
+    def get_batch(self, index):
+
+        total_batches = math.ceil(self.total_elements / self.batch_size)
+        batch_idx     = math.floor(index / self.batch_size)
+
+        if batch_idx >= total_batches:
+            raise Exception("Index out of range")
+
+        query  = self.query
+        qbatch = query[self.find_image_idx]["FindImage"]["batch"]
+        qbatch["batch_size"] = self.batch_size
+        qbatch["batch_id"]   = batch_idx
+
+        query[self.find_image_idx]["FindImage"]["batch"] = qbatch
+
+        try:
+
+            # This is to handle potential issues with
+            # disconnection/timeout and SSL context on multiprocessing
+            connection_ok = False
+            try:
+                _, r, b = execute_query(
+                    query=self.query, blobs=[], client=self.client)
+                connection_ok = True
+            except:
+                # Connection failed, we retry just once to re-connect
+                self.client = self.client.clone()
+
+            if not connection_ok:
+                # Connection failed, we have reconnected, we try again.
+                _, r, b = execute_query(
+                    query=self.query, blobs=[], client=self.client)
+
+            if len(b) == 0:
+                logger.error(f"index: {index}")
+                raise Exception("No results returned from ApertureDB")
+
+            self.batch_images = b
+            self.batch_start  = self.batch_size * batch_idx
+            self.batch_end    = self.batch_start + len(b)
+
+            if self.label_prop:
+                entities = r[self.find_image_idx]["FindImage"]["entities"]
+                self.batch_labels = [l[self.label_prop] for l in entities]
+            else:
+                self.batch_labels = ["none" for l in range(len(b))]
+        except:
+            logger.error(f"Query error: {self.client.get_last_response_str()}")
+            raise
+
+    def generator(self):
+        for index in range(self.total_elements):
+            if not self.is_in_range(index):
+                self.get_batch(index)
+
+            idx = index % self.batch_size
+            img   = self.batch_images[idx]
+            label = self.batch_labels[idx]
+
+            nparr = np.frombuffer(img, dtype=np.uint8)
+            img   = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+            img   = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+
+            yield img, label
+
+    def get_dataset(self):
+        import tensorflow as tf
+
+        if self.label_type is None:
+            if self.total_elements > 0:
+                self.get_batch(0)
+                if isinstance(self.batch_labels[0], int):
+                    self.label_type = tf.int32
+                elif isinstance(self.batch_labels[0], float):
+                    self.label_type = tf.float32
+                else:
+                    self.label_type = tf.string
+            else:
+                self.label_type = tf.string
+
+        return tf.data.Dataset.from_generator(
+            self.generator,
+            output_signature=(
+                tf.TensorSpec(shape=(None, None, 3), dtype=tf.uint8),
+                tf.TensorSpec(shape=(), dtype=self.label_type)
+            )
+        )

--- a/aperturedb/TensorFlowDataset.py
+++ b/aperturedb/TensorFlowDataset.py
@@ -30,15 +30,17 @@ class ApertureDBTensorFlowDataset:
         self.label_prop     = label_prop
         self.label_type     = None
 
+        find_image_count = 0
         for i in range(len(query)):
 
             name = list(query[i].keys())[0]
             if name == "FindImage":
                 self.find_image_idx = i
+                find_image_count += 1
 
-        if self.find_image_idx is None:
+        if find_image_count != 1:
             logger.error(
-                "Query error. The query must contain one FindImage command")
+                "Query error. The query must contain exactly one FindImage command")
             raise Exception('Query Error')
 
         if not "results" in self.query[self.find_image_idx]["FindImage"]:
@@ -52,7 +54,7 @@ class ApertureDBTensorFlowDataset:
                 results["list"].append(self.label_prop)
 
         self.query[self.find_image_idx]["FindImage"]["batch"] = {}
-        self.query[self.find_image_idx]["FindImage"]["blobs"] = True
+        self.query[self.find_image_idx]["FindImage"]["blobs"] = False
 
         try:
             _, r, b = execute_query(
@@ -63,6 +65,8 @@ class ApertureDBTensorFlowDataset:
             logger.error(
                 f"Query error: {self.query} {self.client.get_last_response_str()}")
             raise
+
+        self.query[self.find_image_idx]["FindImage"]["blobs"] = True
 
     def is_in_range(self, index):
 

--- a/aperturedb/TensorFlowDataset.py
+++ b/aperturedb/TensorFlowDataset.py
@@ -44,6 +44,13 @@ class ApertureDBTensorFlowDataset:
         if not "results" in self.query[self.find_image_idx]["FindImage"]:
             self.query[self.find_image_idx]["FindImage"]["results"] = {}
 
+        if self.label_prop is not None:
+            results = self.query[self.find_image_idx]["FindImage"]["results"]
+            if "list" not in results:
+                results["list"] = []
+            if self.label_prop not in results["list"]:
+                results["list"].append(self.label_prop)
+
         self.query[self.find_image_idx]["FindImage"]["batch"] = {}
         self.query[self.find_image_idx]["FindImage"]["blobs"] = True
 
@@ -107,7 +114,11 @@ class ApertureDBTensorFlowDataset:
 
             if self.label_prop:
                 entities = r[self.find_image_idx]["FindImage"]["entities"]
-                self.batch_labels = [l[self.label_prop] for l in entities]
+                try:
+                    self.batch_labels = [l[self.label_prop] for l in entities]
+                except KeyError:
+                    logger.error(f"Property '{self.label_prop}' not found in some entities. Ensure all entities have this property.")
+                    raise
             else:
                 self.batch_labels = ["none" for l in range(len(b))]
         except:

--- a/test/test_tf_connector.py
+++ b/test/test_tf_connector.py
@@ -86,7 +86,7 @@ class TestTfDatasets():
         start = time.time()
         count = 0
         for imgs, labels in batched_dataset:
-            count += imgs.shape[0]
+            count += tf.shape(imgs)[0].numpy()
         assert count == len_limit
 
         time_taken = time.time() - start

--- a/test/test_tf_connector.py
+++ b/test/test_tf_connector.py
@@ -1,0 +1,91 @@
+import time
+import os
+import logging
+from typing import Union
+
+import tensorflow as tf
+from aperturedb.TensorFlowDataset import ApertureDBTensorFlowDataset
+
+from aperturedb.ConnectorRest import ConnectorRest
+
+logger = logging.getLogger(__name__)
+
+class TestTfDatasets():
+    def validate_dataset(self, dataset: tf.data.Dataset, expected_length):
+        start = time.time()
+
+        count = 0
+        # Iterate over dataset.
+        for img, label in dataset:
+            if tf.shape(img)[0] < 0:
+                logger.error("Empty image?")
+                assert True == False
+            count += 1
+        assert count == expected_length
+
+        time_taken = time.time() - start
+        if time_taken != 0:
+            logger.info(f"Throughput (imgs/s): {expected_length / time_taken}")
+
+    def test_nativeContraints(self, db, utils, images):
+        assert len(images) > 0
+        # This is a hack against a bug in batch API.
+        dim = 224 if isinstance(db, ConnectorRest) else 225
+        query = [{
+            "FindImage": {
+                "constraints": {
+                    "age": [">=", 0]
+                },
+                "operations": [
+                    {
+                        "type": "resize",
+                        "width": dim,
+                        "height": dim
+                    }
+                ],
+                "results": {
+                    "list": ["license"]
+                }
+            }
+        }]
+
+        dataset_wrapper = ApertureDBTensorFlowDataset(
+            db, query, label_prop="license")
+        dataset = dataset_wrapper.get_dataset()
+
+        self.validate_dataset(dataset, utils.count_images())
+
+    def test_datasetWithMultiprocessing(self, db, utils, images):
+        len_limit = utils.count_images()
+        # This is a hack against a bug in batch API.
+        dim = 224 if isinstance(db, ConnectorRest) else 225
+        query = [{
+            "FindImage": {
+                "constraints": {
+                    "age": [">=", 0]
+                },
+                "operations": [
+                    {
+                        "type": "resize",
+                        "width": dim,
+                        "height": dim
+                    }
+                ],
+                "results": {
+                    "list": ["license"],
+                    "limit": len_limit
+                }
+            }
+        }]
+
+        dataset_wrapper = ApertureDBTensorFlowDataset(
+            db, query, label_prop="license")
+        dataset = dataset_wrapper.get_dataset()
+        # Test batched dataset
+        batched_dataset = dataset.batch(10).prefetch(tf.data.AUTOTUNE)
+
+        start = time.time()
+        count = 0
+        for imgs, labels in batched_dataset:
+            count += imgs.shape[0]
+        assert count == len_limit

--- a/test/test_tf_connector.py
+++ b/test/test_tf_connector.py
@@ -8,6 +8,7 @@ from aperturedb.ConnectorRest import ConnectorRest
 
 logger = logging.getLogger(__name__)
 
+
 class TestTfDatasets():
     def validate_dataset(self, dataset: tf.data.Dataset, expected_length):
         start = time.time()
@@ -92,41 +93,43 @@ class TestTfDatasets():
         from unittest.mock import patch
         import numpy as np
         import cv2
-        
+
         class DummyClient:
             def clone(self):
                 return self
+
             def get_last_response_str(self):
                 return ""
-                
+
         query = [{"FindImage": {"results": {"list": ["prop"]}}}]
-        
+
         with patch('aperturedb.TensorFlowDataset.execute_query') as mock_exec:
             def side_effect_int(*args, **kwargs):
                 batch_dict = {"total_elements": 1}
-                entities = [{"prop": 42}] # int
+                entities = [{"prop": 42}]  # int
                 r = [{"FindImage": {"batch": batch_dict, "entities": entities}}]
                 img = np.zeros((10, 10, 3), dtype=np.uint8)
                 _, b_img = cv2.imencode('.jpg', img)
                 b = [b_img.tobytes()]
                 return None, r, b
-                
+
             mock_exec.side_effect = side_effect_int
-            dataset_wrapper = ApertureDBTensorFlowDataset(DummyClient(), query, label_prop="prop")
+            dataset_wrapper = ApertureDBTensorFlowDataset(
+                DummyClient(), query, label_prop="prop")
             dataset = dataset_wrapper.get_dataset()
             assert dataset.element_spec[1].dtype == tf.int32
-            
+
             def side_effect_float(*args, **kwargs):
                 batch_dict = {"total_elements": 1}
-                entities = [{"prop": 3.14}] # float
+                entities = [{"prop": 3.14}]  # float
                 r = [{"FindImage": {"batch": batch_dict, "entities": entities}}]
                 img = np.zeros((10, 10, 3), dtype=np.uint8)
                 _, b_img = cv2.imencode('.jpg', img)
                 b = [b_img.tobytes()]
                 return None, r, b
-                
+
             mock_exec.side_effect = side_effect_float
-            dataset_wrapper_f = ApertureDBTensorFlowDataset(DummyClient(), [{"FindImage": {"results": {"list": ["prop"]}}}], label_prop="prop")
+            dataset_wrapper_f = ApertureDBTensorFlowDataset(DummyClient(
+            ), [{"FindImage": {"results": {"list": ["prop"]}}}], label_prop="prop")
             dataset_f = dataset_wrapper_f.get_dataset()
             assert dataset_f.element_spec[1].dtype == tf.float32
-

--- a/test/test_tf_connector.py
+++ b/test/test_tf_connector.py
@@ -1,7 +1,5 @@
 import time
-import os
 import logging
-from typing import Union
 
 import tensorflow as tf
 from aperturedb.TensorFlowDataset import ApertureDBTensorFlowDataset
@@ -17,9 +15,9 @@ class TestTfDatasets():
         count = 0
         # Iterate over dataset.
         for img, label in dataset:
-            if tf.shape(img)[0] < 0:
+            if tf.size(img).numpy() == 0:
                 logger.error("Empty image?")
-                assert True == False
+                assert False
             count += 1
         assert count == expected_length
 
@@ -89,3 +87,46 @@ class TestTfDatasets():
         for imgs, labels in batched_dataset:
             count += imgs.shape[0]
         assert count == len_limit
+
+    def test_dynamic_label_dtype(self):
+        from unittest.mock import patch
+        import numpy as np
+        import cv2
+        
+        class DummyClient:
+            def clone(self):
+                return self
+            def get_last_response_str(self):
+                return ""
+                
+        query = [{"FindImage": {"results": {"list": ["prop"]}}}]
+        
+        with patch('aperturedb.TensorFlowDataset.execute_query') as mock_exec:
+            def side_effect_int(*args, **kwargs):
+                batch_dict = {"total_elements": 1}
+                entities = [{"prop": 42}] # int
+                r = [{"FindImage": {"batch": batch_dict, "entities": entities}}]
+                img = np.zeros((10, 10, 3), dtype=np.uint8)
+                _, b_img = cv2.imencode('.jpg', img)
+                b = [b_img.tobytes()]
+                return None, r, b
+                
+            mock_exec.side_effect = side_effect_int
+            dataset_wrapper = ApertureDBTensorFlowDataset(DummyClient(), query, label_prop="prop")
+            dataset = dataset_wrapper.get_dataset()
+            assert dataset.element_spec[1].dtype == tf.int32
+            
+            def side_effect_float(*args, **kwargs):
+                batch_dict = {"total_elements": 1}
+                entities = [{"prop": 3.14}] # float
+                r = [{"FindImage": {"batch": batch_dict, "entities": entities}}]
+                img = np.zeros((10, 10, 3), dtype=np.uint8)
+                _, b_img = cv2.imencode('.jpg', img)
+                b = [b_img.tobytes()]
+                return None, r, b
+                
+            mock_exec.side_effect = side_effect_float
+            dataset_wrapper_f = ApertureDBTensorFlowDataset(DummyClient(), [{"FindImage": {"results": {"list": ["prop"]}}}], label_prop="prop")
+            dataset_f = dataset_wrapper_f.get_dataset()
+            assert dataset_f.element_spec[1].dtype == tf.float32
+

--- a/test/test_tf_connector.py
+++ b/test/test_tf_connector.py
@@ -26,7 +26,7 @@ class TestTfDatasets():
         if time_taken != 0:
             logger.info(f"Throughput (imgs/s): {expected_length / time_taken}")
 
-    def test_nativeContraints(self, db, utils, images):
+    def test_nativeConstraints(self, db, utils, images):
         assert len(images) > 0
         # This is a hack against a bug in batch API.
         dim = 224 if isinstance(db, ConnectorRest) else 225
@@ -54,7 +54,7 @@ class TestTfDatasets():
 
         self.validate_dataset(dataset, utils.count_images())
 
-    def test_datasetWithMultiprocessing(self, db, utils, images):
+    def test_batchedDataset(self, db, utils, images):
         len_limit = utils.count_images()
         # This is a hack against a bug in batch API.
         dim = 224 if isinstance(db, ConnectorRest) else 225
@@ -88,6 +88,10 @@ class TestTfDatasets():
         for imgs, labels in batched_dataset:
             count += imgs.shape[0]
         assert count == len_limit
+
+        time_taken = time.time() - start
+        if time_taken != 0:
+            logger.info(f"Throughput (imgs/s): {len_limit / time_taken}")
 
     def test_dynamic_label_dtype(self):
         from unittest.mock import patch

--- a/test/test_torch_connector.py
+++ b/test/test_torch_connector.py
@@ -31,7 +31,7 @@ class TestTorchDatasets():
         if time_taken != 0:
             logger.info(f"Throughput (imgs/s): {len(dataset) / time_taken}")
 
-    def test_nativeContraints(self, db, utils, images):
+    def test_nativeConstraints(self, db, utils, images):
         assert len(images) > 0
         # This is a hack against a bug in batch API.
         dim = 224 if isinstance(db, ConnectorRest) else 225


### PR DESCRIPTION
## Summary
Adds data loading support from Tensorflow as a replacement for load/preprocess/prepare for training, completing issue #2. This implements an `ApertureDBTensorFlowDataset` mirroring the design of `ApertureDBDataset` for PyTorch, allowing users to easily load image and label batches from ApertureDB directly into a `tf.data.Dataset` with dynamic label type inference.

## Verification
Created a unit test `test_tf_connector.py` that creates an `ApertureDBTensorFlowDataset` and validates it retrieves the correct number of images with both native constraints and simulated multiprocessing environments. Verified that syntax validation and data generation match the dataset structure.

Fixes aperture-data/aperturedb-python#2