### PR TITLE
fix: check all statuses in check_status to report errors properly

### DIFF
--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -25,7 +25,7 @@
 # THE SOFTWARE.
 #
 from __future__ import annotations
-from typing import Optional
+from typing import Optional, Any
 from . import queryMessage
 import sys
 import os
@@ -45,6 +45,7 @@ from dataclasses import dataclass
 from aperturedb.Configuration import Configuration
 from aperturedb.types import CommandResponses
 from aperturedb.LoggingUtils import censor_tokens
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -669,14 +670,14 @@ class Connector(object):
 
         return self.check_status(self.response) >= 0
 
-    def check_status(self, json_res: CommandResponses) -> int:
+    def check_status(self, json_res: Any) -> int:
         """
         Returns the status of the first negative command response from the server,
         or the status of the first command if all are non-negative.
-        Can traverse a JSON recursively to find the statuses.
+        Can traverse a JSON recursively (descending into the first key of a dictionary) to find the statuses.
 
         Args:
-            json_res (CommandResponses): The actual response from the server.
+            json_res (Any): The actual response from the server.
 
         Returns:
             int: The value received from the server, or -2 if not found.

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -688,9 +688,14 @@ class Connector(object):
             else:
                 status = json_res["status"]
         elif (isinstance(json_res, (tuple, list))):
-            if ("status" not in json_res[0]):
-                status = self.check_status(json_res[0])
-            else:
-                status = json_res[0]["status"]
+            for res in json_res:
+                st = self.check_status(res)
+                if st < 0:
+                    return st
+            if len(json_res) > 0:
+                if ("status" not in json_res[0]):
+                    status = self.check_status(json_res[0])
+                else:
+                    status = json_res[0]["status"]
 
         return status

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -671,14 +671,15 @@ class Connector(object):
 
     def check_status(self, json_res: CommandResponses) -> int:
         """
-        Returns the status of the first command response from the server.
-        Can traverse a JSON recursively to find the first status.
+        Returns the status of the first negative command response from the server,
+        or the status of the first command if all are non-negative.
+        Can traverse a JSON recursively to find the statuses.
 
         Args:
             json_res (CommandResponses): The actual response from the server.
 
         Returns:
-            int: The value recieved from the server, or -2 if not found.
+            int: The value received from the server, or -2 if not found.
         """
         # Default status is -2, which is an error, but not a server error.
         status = STATUS_ERROR_DEFAULT

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -43,9 +43,7 @@ from threading import Lock
 from types import SimpleNamespace
 from dataclasses import dataclass
 from aperturedb.Configuration import Configuration
-from aperturedb.types import CommandResponses
 from aperturedb.LoggingUtils import censor_tokens
-from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -688,14 +688,11 @@ class Connector(object):
             else:
                 status = json_res["status"]
         elif (isinstance(json_res, (tuple, list))):
-            for res in json_res:
+            for i, res in enumerate(json_res):
                 st = self.check_status(res)
+                if i == 0:
+                    status = st
                 if st < 0:
                     return st
-            if len(json_res) > 0:
-                if ("status" not in json_res[0]):
-                    status = self.check_status(json_res[0])
-                else:
-                    status = json_res[0]["status"]
 
         return status

--- a/aperturedb/Connector.py
+++ b/aperturedb/Connector.py
@@ -674,7 +674,7 @@ class Connector(object):
         """
         Returns the status of the first negative command response from the server,
         or the status of the first command if all are non-negative.
-        Can traverse a JSON recursively (descending into the first key of a dictionary) to find the statuses.
+        Can traverse a JSON recursively to find the statuses.
 
         Args:
             json_res (Any): The actual response from the server.
@@ -686,7 +686,12 @@ class Connector(object):
         status = STATUS_ERROR_DEFAULT
         if (isinstance(json_res, dict)):
             if ("status" not in json_res):
-                status = self.check_status(json_res[list(json_res.keys())[0]])
+                for i, val in enumerate(json_res.values()):
+                    st = self.check_status(val)
+                    if i == 0:
+                        status = st
+                    if st < 0:
+                        return st
             else:
                 status = json_res["status"]
         elif (isinstance(json_res, (tuple, list))):

--- a/test/test_Connector.py
+++ b/test/test_Connector.py
@@ -1,0 +1,27 @@
+from aperturedb.Connector import Connector
+
+
+class TestConnector:
+    def test_check_status_mixed(self):
+        # We don't need a real connection, just the check_status method
+        connector = Connector(connect=False)
+
+        # Test case 1: all ok
+        res1 = [{"FindImage": {"status": 0}}, {"FindImage": {"status": 0}}]
+        assert connector.check_status(res1) == 0
+
+        # Test case 2: first is ok, second is negative
+        res2 = [{"FindImage": {"status": 0}}, {"FindImage": {"status": -2}}]
+        assert connector.check_status(res2) == -2
+
+        # Test case 3: first is negative, second is ok
+        res3 = [{"FindImage": {"status": -1}}, {"FindImage": {"status": 0}}]
+        assert connector.check_status(res3) == -1
+
+        # Test case 4: deeply nested dict
+        res4 = {"FindImage": {"status": 0}}
+        assert connector.check_status(res4) == 0
+
+        # Test case 5: nested ok, nested negative
+        res5 = [{"AddImage": {"status": 0}}, {"AddEntity": {"status": -3}}]
+        assert connector.check_status(res5) == -3

--- a/test/test_Connector.py
+++ b/test/test_Connector.py
@@ -11,8 +11,8 @@ class TestConnector:
         assert connector.check_status(res1) == 0
 
         # Test case 2: first is ok, second is negative
-        res2 = [{"FindImage": {"status": 0}}, {"FindImage": {"status": -2}}]
-        assert connector.check_status(res2) == -2
+        res2 = [{"FindImage": {"status": 0}}, {"FindImage": {"status": -4}}]
+        assert connector.check_status(res2) == -4
 
         # Test case 3: first is negative, second is ok
         res3 = [{"FindImage": {"status": -1}}, {"FindImage": {"status": 0}}]

--- a/test/test_Connector.py
+++ b/test/test_Connector.py
@@ -25,3 +25,7 @@ class TestConnector:
         # Test case 5: nested ok, nested negative
         res5 = [{"AddImage": {"status": 0}}, {"AddEntity": {"status": -3}}]
         assert connector.check_status(res5) == -3
+
+        # Test case 6: multiple keys in a single dict (tests values traversal)
+        res6 = {"FindImage": {"status": 0}, "FindEntity": {"status": -4}}
+        assert connector.check_status(res6) == -4


### PR DESCRIPTION
## Summary
- Modifies \`check_status\` to iterate over all items in a list response and return the first error status if any.
- This ensures \`last_query_ok()\` returns False when there are partial errors, reporting them properly rather than silently ignoring them or failing during blob handler parsing.

## Verification
- Verified logic manually. Tests are failing locally due to an unreachable test database (`lenz:55551`).

Fixes aperture-data/aperturedb-python#165.