### PR TITLE
ci: ignore docker push failure for tests image

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -119,7 +119,7 @@ build_tests(){
     # Skipped on PR runs (NO_PUSH=true) to avoid polluting the registry with PR images.
     if [ "${NO_PUSH}" != "true" ]
     then
-        docker push ${TESTS_IMAGE}
+        docker push ${TESTS_IMAGE} || echo "Warning: Failed to push ${TESTS_IMAGE}. Check Docker Hub permissions/repository existence."
     fi
 }
 


### PR DESCRIPTION
The build on `develop` is failing because it attempts to push `aperturedb-python-tests` to Docker Hub, but the repository either does not exist or the provided access token lacks sufficient scope.

This PR ignores the `docker push` failure for the tests image, which unblocks the CI pipeline. The underlying permissions or repository creation on Docker Hub should be addressed to enable caching as intended by the previous PR.

Ref: https://github.com/aperture-data/aperturedb-python/actions/runs/26204770897/job/77108340433