### PR TITLE
fix: Decouple use_dask from CSV parser and make it a property of parallelizer

### DIFF
--- a/aperturedb/BlobNewestDataCSV.py
+++ b/aperturedb/BlobNewestDataCSV.py
@@ -282,17 +282,16 @@ class BlobNewestDataCSV(CSVParser.CSVParser):
     def validate(self):
         self._setupkeys()
         valid = True
-        if not self.use_dask:
-            if len(self.constraints_keys) < 1:
-                logger.error("Cannot add/update " +
-                             self.entity + "; no constraint keys")
-                valid = False
-            if valid and len(self.search_keys) < 1:
-                logger.error("Cannot update " + self.entity +
-                             "; no update constraint keys")
-                valid = False
-            if len(self.filter_generated_constraints()) < 1:
-                logger.error("Cannot differentiate update and reinsert for  " +
-                             self.__class__.__name__ + ": no generated constraints for blob comparison")
-                valid = False
+        if len(self.constraints_keys) < 1:
+            logger.error("Cannot add/update " +
+                         self.entity + "; no constraint keys")
+            valid = False
+        if valid and len(self.search_keys) < 1:
+            logger.error("Cannot update " + self.entity +
+                         "; no update constraint keys")
+            valid = False
+        if len(self.filter_generated_constraints()) < 1:
+            logger.error("Cannot differentiate update and reinsert for  " +
+                         self.__class__.__name__ + ": no generated constraints for blob comparison")
+            valid = False
         return valid

--- a/aperturedb/CSVParser.py
+++ b/aperturedb/CSVParser.py
@@ -51,13 +51,17 @@ class CSVParser(Subscriptable):
         # The following are extracted from the kwargs.
         self.blobs_relative_to_csv = "blobs_relative_to_csv" in kwargs and kwargs[
             "blobs_relative_to_csv"]
+        self.use_dask = kwargs.get("use_dask", False)
         df = kwargs["df"] if "df" in kwargs else None
 
         self.relative_path_prefix = os.path.dirname(self.filename) if self.blobs_relative_to_csv \
             else ""
 
         if df is None:
-            self.df = pd.read_csv(filename)
+            if self.use_dask:
+                self.df = pd.read_csv(filename, nrows=0)
+            else:
+                self.df = pd.read_csv(filename)
         else:
             self.df = df
 
@@ -68,7 +72,7 @@ class CSVParser(Subscriptable):
             raise TypeError(
                 f"CSVParser requires a RangeIndex. the supplied DataFrame has a {type(self.df.index)} index.")
 
-        if len(self.df) == 0:
+        if not self.use_dask and len(self.df) == 0:
             logger.error("Dataframe empty. Is the CSV file ok?")
 
         self.df = self.df.astype('object')

--- a/aperturedb/CSVParser.py
+++ b/aperturedb/CSVParser.py
@@ -51,43 +51,24 @@ class CSVParser(Subscriptable):
         # The following are extracted from the kwargs.
         self.blobs_relative_to_csv = "blobs_relative_to_csv" in kwargs and kwargs[
             "blobs_relative_to_csv"]
-        self.use_dask = "use_dask" in kwargs and kwargs["use_dask"]
         df = kwargs["df"] if "df" in kwargs else None
 
         self.relative_path_prefix = os.path.dirname(self.filename) if self.blobs_relative_to_csv \
             else ""
 
-        if not self.use_dask:
-            if df is None:
-                self.df = pd.read_csv(filename)
-            else:
-                self.df = df
-
-            # we expect the df index to have 'start', which means RangeIndex.
-            # most users don't supply their own df, so this is mostly a sanity check
-            # for when an advanced user has done filtering and have a IntervalIndex.
-            if not isinstance(self.df.index, pd.RangeIndex):
-                raise TypeError(
-                    f"CSVParser requires a RangeIndex. the supplied DataFrame has a {type(self.df.index)} index.")
+        if df is None:
+            self.df = pd.read_csv(filename)
         else:
-            if df is not None:
-                raise ValueError(
-                    "Dask mode requires a CSV filename; DataFrame inputs are not supported.")
-            # It'll impact the number of partitions, and memory usage.
-            # TODO: tune this for the best performance.
-            cores_used = int(CORES_USED_FOR_PARALLELIZATION * mp.cpu_count())
-            blocksize = os.path.getsize(
-                self.filename) // (cores_used * PARTITIONS_PER_CORE)
-            if blocksize == 0:
-                cpus = mp.cpu_count()
-                raise Exception(
-                    f"CSV file too small to be read in parallel. Use normal mode. cpus: {cpus}")
-            self.df = dataframe.read_csv(
-                self.filename,
-                blocksize=blocksize)
+            self.df = df
 
-        # len for dask dataframe needs a client.
-        if not self.use_dask and len(self.df) == 0:
+        # we expect the df index to have 'start', which means RangeIndex.
+        # most users don't supply their own df, so this is mostly a sanity check
+        # for when an advanced user has done filtering and have a IntervalIndex.
+        if not isinstance(self.df.index, pd.RangeIndex):
+            raise TypeError(
+                f"CSVParser requires a RangeIndex. the supplied DataFrame has a {type(self.df.index)} index.")
+
+        if len(self.df) == 0:
             logger.error("Dataframe empty. Is the CSV file ok?")
 
         self.df = self.df.astype('object')

--- a/aperturedb/DaskManager.py
+++ b/aperturedb/DaskManager.py
@@ -100,7 +100,33 @@ class DaskManager:
         start_time = time.time()
         # Connector cannot be serialized across processes,
         # so we pass session and host/port information instead.
-        computation = generator.df.map_partitions(
+        
+        if not hasattr(generator.df, "map_partitions"):
+            # If generator.df is a Pandas DataFrame, convert to Dask DataFrame
+            # Alternatively, if it has a filename, we could read it directly with dask.
+            import dask.dataframe as dd
+            import os
+            import multiprocessing as mp
+            PARTITIONS_PER_CORE = 10
+            CORES_USED_FOR_PARALLELIZATION = 0.9
+            
+            if hasattr(generator, "filename") and generator.filename:
+                cores_used = int(CORES_USED_FOR_PARALLELIZATION * mp.cpu_count())
+                blocksize = os.path.getsize(
+                    generator.filename) // (cores_used * PARTITIONS_PER_CORE)
+                if blocksize == 0:
+                    cpus = mp.cpu_count()
+                    raise Exception(
+                        f"CSV file too small to be read in parallel. Use normal mode. cpus: {cpus}")
+                dask_df = dd.read_csv(
+                    generator.filename,
+                    blocksize=blocksize)
+            else:
+                dask_df = dd.from_pandas(generator.df, npartitions=self.__num_workers * 2 if self.__num_workers > 0 else mp.cpu_count())
+        else:
+            dask_df = generator.df
+
+        computation = dask_df.map_partitions(
             process,
             client.host,
             client.port,

--- a/aperturedb/DaskManager.py
+++ b/aperturedb/DaskManager.py
@@ -100,7 +100,7 @@ class DaskManager:
         start_time = time.time()
         # Connector cannot be serialized across processes,
         # so we pass session and host/port information instead.
-        
+
         if not hasattr(generator.df, "map_partitions"):
             # If generator.df is a Pandas DataFrame, convert to Dask DataFrame
             # Alternatively, if it has a filename, we could read it directly with dask.
@@ -109,9 +109,10 @@ class DaskManager:
             import multiprocessing as mp
             PARTITIONS_PER_CORE = 10
             CORES_USED_FOR_PARALLELIZATION = 0.9
-            
+
             if hasattr(generator, "filename") and generator.filename:
-                cores_used = int(CORES_USED_FOR_PARALLELIZATION * mp.cpu_count())
+                cores_used = int(
+                    CORES_USED_FOR_PARALLELIZATION * mp.cpu_count())
                 blocksize = os.path.getsize(
                     generator.filename) // (cores_used * PARTITIONS_PER_CORE)
                 if blocksize == 0:
@@ -122,7 +123,8 @@ class DaskManager:
                     generator.filename,
                     blocksize=blocksize)
             else:
-                dask_df = dd.from_pandas(generator.df, npartitions=self.__num_workers * 2 if self.__num_workers > 0 else mp.cpu_count())
+                dask_df = dd.from_pandas(
+                    generator.df, npartitions=self.__num_workers * 2 if self.__num_workers > 0 else mp.cpu_count())
         else:
             dask_df = generator.df
 

--- a/aperturedb/DaskManager.py
+++ b/aperturedb/DaskManager.py
@@ -83,9 +83,9 @@ class DaskManager:
                 end = min(i + batchsize, len(df))
                 slice = df[i:end]
                 data = generator.__class__(
-                    filename=generator.filename,
+                    filename=getattr(generator, "filename", None),
                     df=slice,
-                    blobs_relative_to_csv=generator.blobs_relative_to_csv)
+                    blobs_relative_to_csv=getattr(generator, "blobs_relative_to_csv", False))
 
                 loader.query(generator=data, batchsize=len(
                     slice), numthreads=1, stats=False)
@@ -100,6 +100,9 @@ class DaskManager:
         start_time = time.time()
         # Connector cannot be serialized across processes,
         # so we pass session and host/port information instead.
+
+        if not hasattr(generator, "df"):
+            raise ValueError("Dask mode requires a generator with a 'df' attribute.")
 
         if not hasattr(generator.df, "map_partitions"):
             # If generator.df is a Pandas DataFrame, convert to Dask DataFrame

--- a/aperturedb/DaskManager.py
+++ b/aperturedb/DaskManager.py
@@ -113,8 +113,8 @@ class DaskManager:
             CORES_USED_FOR_PARALLELIZATION = 0.9
 
             if hasattr(generator, "filename") and generator.filename:
-                cores_used = int(
-                    CORES_USED_FOR_PARALLELIZATION * mp.cpu_count())
+                cores_used = max(1, int(
+                    CORES_USED_FOR_PARALLELIZATION * mp.cpu_count()))
                 blocksize = os.path.getsize(
                     generator.filename) // (cores_used * PARTITIONS_PER_CORE)
                 if blocksize == 0:

--- a/aperturedb/DaskManager.py
+++ b/aperturedb/DaskManager.py
@@ -82,10 +82,9 @@ class DaskManager:
             for i in range(0, len(df), batchsize):
                 end = min(i + batchsize, len(df))
                 slice = df[i:end]
-                data = generator.__class__(
-                    filename=getattr(generator, "filename", None),
-                    df=slice,
-                    blobs_relative_to_csv=getattr(generator, "blobs_relative_to_csv", False))
+                import copy
+                data = copy.copy(generator)
+                data.df = slice
 
                 loader.query(generator=data, batchsize=len(
                     slice), numthreads=1, stats=False)

--- a/aperturedb/EntityDataCSV.py
+++ b/aperturedb/EntityDataCSV.py
@@ -116,12 +116,11 @@ class EntityDeleteDataCSV(CSVParser.CSVParser):
 
     """
 
-    def __init__(self, entity_class, filename, df=None, use_dask=False):
-        super().__init__(filename, df=df, use_dask=use_dask)
+    def __init__(self, entity_class, filename, df=None):
+        super().__init__(filename, df=df)
         self.command = "Delete" + entity_class
         self.constraint_keyword = "constraints"
-        if not use_dask:
-            self.constraint_keys = [x for x in self.header[0:]]
+        self.constraint_keys = [x for x in self.header[0:]]
 
     def getitem(self, idx):
         idx = self.df.index.start + idx
@@ -143,5 +142,5 @@ class ImageDeleteDataCSV(EntityDeleteDataCSV):
     Usage details in EntityDeleteDataCSV
     """
 
-    def __init__(self, filename, df=None, use_dask=False):
-        super().__init__("Image", filename, df=df, use_dask=use_dask)
+    def __init__(self, filename, df=None):
+        super().__init__("Image", filename, df=df)

--- a/aperturedb/EntityDataCSV.py
+++ b/aperturedb/EntityDataCSV.py
@@ -41,8 +41,8 @@ class EntityDataCSV(CSVParser.CSVParser):
 
     """
 
-    def __init__(self, filename: str, **kwargs):
-        super().__init__(filename, **kwargs)
+    def __init__(self, filename: str, use_dask: bool = False, **kwargs):
+        super().__init__(filename, use_dask=use_dask, **kwargs)
 
         self.props_keys = [x for x in self.header[1:]
                            if not x.startswith(CSVParser.CONSTRAINTS_PREFIX)]

--- a/aperturedb/EntityUpdateDataCSV.py
+++ b/aperturedb/EntityUpdateDataCSV.py
@@ -130,21 +130,20 @@ class SingleEntityUpdateDataCSV(CSVParser.CSVParser):
     def validate(self):
         self._setupkeys()
         valid = True
-        if not self.use_dask:
-            if len(self.constraints_keys) < 1:
-                logger.error("Cannot add/update " +
-                             self.entity + "; no constraint keys")
-                valid = False
-            if valid and len(self.search_keys) < 1:
-                logger.error("Cannot update " + self.entity +
-                             "; no update constraint keys")
-                valid = False
+        if len(self.constraints_keys) < 1:
+            logger.error("Cannot add/update " +
+                         self.entity + "; no constraint keys")
+            valid = False
+        if valid and len(self.search_keys) < 1:
+            logger.error("Cannot update " + self.entity +
+                         "; no update constraint keys")
+            valid = False
         return valid
 
 
 class EntityUpdatDataCSV(SingleEntityUpdateDataCSV):
-    def __init__(self, entity_type, filename, df=None, use_dask=False):
-        super().__init__("Entity", filename, df, use_dask)
+    def __init__(self, entity_type, filename, df=None):
+        super().__init__("Entity", filename, df)
         self.entity_type = entity_type
         # Add had blob and update has blob.
         self.blobs_per_query = [0, 0]

--- a/aperturedb/EntityUpdateDataCSV.py
+++ b/aperturedb/EntityUpdateDataCSV.py
@@ -71,7 +71,7 @@ class SingleEntityUpdateDataCSV(CSVParser.CSVParser):
     """
     UPDATE_CONSTRAINT_PREFIX = "updateif_"
 
-    def __init__(self, entity_class: str, filename: str, **kwargs):
+    def __init__(self, entity_class: str, filename: str, use_dask: bool = False, **kwargs):
 
         if entity_class in ("Image", "Video", "Blob", "BoundingBox", "Connection", "Polygon", "Descriptor", "DescriptorSet", "Frame"):
             self.entity = entity_class
@@ -80,7 +80,7 @@ class SingleEntityUpdateDataCSV(CSVParser.CSVParser):
             self.entity = "Entity"
             self.entity_selection = entity_class
         self.keys_set = False
-        super().__init__(filename, **kwargs)
+        super().__init__(filename, use_dask=use_dask, **kwargs)
         # We do not expect a blob in either query, if a subclass adds blob, the first query will need a blob.
         self.blobs_per_query = [0, 0]
         self.commands_per_query = [1, 1]

--- a/aperturedb/EntityUpdateDataCSV.py
+++ b/aperturedb/EntityUpdateDataCSV.py
@@ -143,7 +143,7 @@ class SingleEntityUpdateDataCSV(CSVParser.CSVParser):
 
 class EntityUpdatDataCSV(SingleEntityUpdateDataCSV):
     def __init__(self, entity_type, filename, df=None):
-        super().__init__("Entity", filename, df)
+        super().__init__("Entity", filename, df=df)
         self.entity_type = entity_type
         # Add had blob and update has blob.
         self.blobs_per_query = [0, 0]

--- a/aperturedb/ImageDataCSV.py
+++ b/aperturedb/ImageDataCSV.py
@@ -35,17 +35,9 @@ class ImageDataProcessor():
         self.check_image = check_image
         self.n_download_retries = n_download_retries
 
-    def set_processor(self, use_dask: bool, source_type):
+    def set_processor(self, source_type):
         self.source_type = source_type
-        if use_dask == False and self.source_type == HEADER_S3_URL:
-            # The connections by boto3 cause ResourceWarning. Known
-            # issue: https://github.com/boto/boto3/issues/454
-            s3_client = boto3.client('s3')
-            self.sources = Sources(
-                self.n_download_retries,
-                s3_client=s3_client)
-        else:
-            self.sources = Sources(self.n_download_retries)
+        self.sources = Sources(self.n_download_retries)
 
     def get_indices(self):
         return {
@@ -179,7 +171,7 @@ class ImageDataCSV(CSVParser.CSVParser, ImageDataProcessor):
         CSVParser.CSVParser.__init__(self, filename, **kwargs)
 
         source_type = self.header[0]
-        self.set_processor(self.use_dask, source_type)
+        self.set_processor(source_type)
 
         self.format_given = IMG_FORMAT in self.header
         self.props_keys = [x for x in self.header[1:]
@@ -263,7 +255,7 @@ class ImageUpdateDataCSV(SingleEntityUpdateDataCSV, ImageDataProcessor):
             self, "Image", filename, **kwargs)
 
         source_type = self.header[0]
-        self.set_processor(self.use_dask, source_type)
+        self.set_processor(source_type)
 
         # this class loads a blob, so must set the first query to have a blob.
         self.blobs_per_query = [1, 0]
@@ -316,7 +308,7 @@ class ImageForceNewestDataCSV(BlobNewestDataCSV, ImageDataProcessor):
             self, "Image", filename, **kwargs)
 
         source_type = self.header[0]
-        self.set_processor(self.use_dask, source_type)
+        self.set_processor(source_type)
 
         self.format_given = IMG_FORMAT in self.header
         self.props_keys = list(filter(lambda prop: prop not in [
@@ -371,7 +363,7 @@ class ImageSparseAddDataCSV(SparseAddingDataCSV, ImageDataProcessor):
             self, check_image, n_download_retries)
         SparseAddingDataCSV.__init__(self, "Image", filename, **kwargs)
         source_type = self.header[0]
-        self.set_processor(self.use_dask, source_type)
+        self.set_processor(source_type)
 
         self.format_given = IMG_FORMAT in self.header
         self.props_keys = list(filter(lambda prop: prop not in [

--- a/aperturedb/ParallelLoader.py
+++ b/aperturedb/ParallelLoader.py
@@ -42,8 +42,8 @@ class ParallelLoader(ParallelQuery.ParallelQuery):
     * A class derived from `aperturedb.KaggleData.KaggleData`
     """
 
-    def __init__(self, client: Connector, dry_run: bool = False):
-        super().__init__(client, dry_run=dry_run)
+    def __init__(self, client: Connector, dry_run: bool = False, use_dask: bool = False):
+        super().__init__(client, dry_run=dry_run, use_dask=use_dask)
         self.utils = Utils(self.client)
         self.type = "element"
 

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -277,6 +277,8 @@ class ParallelQuery(Parallelizer.Parallelizer):
         """
 
         if self.use_dask:
+            if not hasattr(generator, "df"):
+                raise ValueError("Dask mode requires a generator with a 'df' attribute.")
             self._reset(batchsize=batchsize, numthreads=numthreads)
             self.daskmanager = DaskManager(num_workers=numthreads)
 

--- a/aperturedb/ParallelQuery.py
+++ b/aperturedb/ParallelQuery.py
@@ -43,8 +43,8 @@ class ParallelQuery(Parallelizer.Parallelizer):
     def getSuccessStatus(cls):
         return cls.success_statuses
 
-    def __init__(self, client: Connector, dry_run: bool = False):
-        super().__init__()
+    def __init__(self, client: Connector, dry_run: bool = False, use_dask: bool = False):
+        super().__init__(use_dask=use_dask)
         test_string = f"Connection test successful with {client.config}"
         try:
             _, _ = client.query([{"GetSchema": {}}], [])
@@ -276,15 +276,14 @@ class ParallelQuery(Parallelizer.Parallelizer):
             stats (bool, optional): Show statistics at end of ingestion. Defaults to False.
         """
 
-        use_dask = hasattr(generator, "use_dask") and generator.use_dask
-        if use_dask:
+        if self.use_dask:
             self._reset(batchsize=batchsize, numthreads=numthreads)
             self.daskmanager = DaskManager(num_workers=numthreads)
 
         if hasattr(self, "query_setup"):
             self.query_setup(generator)
 
-        if use_dask:
+        if self.use_dask:
             results, self.total_actions_time = self.daskmanager.run(
                 self.__class__, self.client, generator, batchsize, stats=stats, dry_run=self.dry_run)
             self.actual_stats = []

--- a/aperturedb/ParallelQuerySet.py
+++ b/aperturedb/ParallelQuerySet.py
@@ -352,9 +352,9 @@ class ParallelQuerySet(ParallelQuery):
         dry_run (bool, optional): If True, no queries are executed. Defaults to False.
     """
 
-    def __init__(self, client: Connector, dry_run: bool = False):
+    def __init__(self, client: Connector, dry_run: bool = False, use_dask: bool = False):
 
-        super().__init__(client, dry_run)
+        super().__init__(client, dry_run, use_dask=use_dask)
 
         self.base_batch_command = self.batch_command
 

--- a/aperturedb/Parallelizer.py
+++ b/aperturedb/Parallelizer.py
@@ -28,7 +28,8 @@ class Parallelizer:
     ```
     """
 
-    def __init__(self):
+    def __init__(self, use_dask: bool = False):
+        self.use_dask = use_dask
         self._reset()
 
     def _reset(self, batchsize: int = 1, numthreads: int = 1):

--- a/aperturedb/SparseAddingDataCSV.py
+++ b/aperturedb/SparseAddingDataCSV.py
@@ -61,9 +61,8 @@ class SparseAddingDataCSV(CSVParser.CSVParser):
     def validate(self):
         self._setupkeys()
         valid = True
-        if not self.use_dask:
-            if len(self.constraints_keys) < 1:
-                logger.error("Cannot add/update " +
-                             self.entity + "; no constraint keys")
-                valid = False
+        if len(self.constraints_keys) < 1:
+            logger.error("Cannot add/update " +
+                         self.entity + "; no constraint keys")
+            valid = False
         return valid

--- a/aperturedb/VideoDataCSV.py
+++ b/aperturedb/VideoDataCSV.py
@@ -89,11 +89,7 @@ class VideoDataCSV(CSVParser.CSVParser):
             HEADER_GS_URL: self.load_gs_url
         }
         self.source_type = self.header[0]
-        if self.use_dask == False and self.source_type == HEADER_S3_URL:
-            s3_client = boto3.client('s3')
-            self.sources = Sources(3, s3_client=s3_client)
-        else:
-            self.sources = Sources(3)
+        self.sources = Sources(3)
 
     def get_indices(self):
         return {

--- a/aperturedb/cli/ingest.py
+++ b/aperturedb/cli/ingest.py
@@ -90,7 +90,7 @@ def _create_pipeline(transformers: List[str]):
     return pipeline
 
 
-def _process_data(data, sample_count, module_name, batchsize, num_workers, stats, debug):
+def _process_data(data, sample_count, module_name, batchsize, num_workers, stats, debug, use_dask=False):
     if debug:
         _debug_samples(data, sample_count, module_name)
     else:
@@ -98,7 +98,7 @@ def _process_data(data, sample_count, module_name, batchsize, num_workers, stats
         from aperturedb.CommonLibrary import create_connector
 
         client = create_connector()
-        loader = ParallelLoader(client)
+        loader = ParallelLoader(client, use_dask=use_dask)
         loader.ingest(
             data,
             stats=stats,
@@ -215,7 +215,7 @@ def from_csv(filepath: Annotated[str, typer.Argument(
         IngestType.VIDEO: VideoDataCSV
     }
 
-    data = ingest_types[ingest_type](filepath, use_dask=use_dask,
+    data = ingest_types[ingest_type](filepath,
                                      blobs_relative_to_csv=blobs_relative_to_csv)
     data.sample_count = len(data) if sample_count == -1 else sample_count
     if transformer or user_transformer:
@@ -232,7 +232,8 @@ def from_csv(filepath: Annotated[str, typer.Argument(
         batchsize=batchsize,
         num_workers=num_workers,
         stats=stats,
-        debug=debug
+        debug=debug,
+        use_dask=use_dask
     )
 
 

--- a/examples/dask/ingest_loader.py
+++ b/examples/dask/ingest_loader.py
@@ -13,8 +13,8 @@ def main(use_dask: bool = False, csv_path: str = "data.csv"):
     client = create_connector()
 
     data = EntityDataCSV(filename=os.path.join(
-        os.path.dirname(__file__), csv_path), use_dask=use_dask)
-    loader = ParallelLoader(client=client)
+        os.path.dirname(__file__), csv_path))
+    loader = ParallelLoader(client=client, use_dask=use_dask)
     loader.ingest(generator=data, batchsize=2000, numthreads=8, stats=True)
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -123,7 +123,7 @@ def insert_data_from_csv(db, request):
         use_dask = False
         if hasattr(request, "param"):
             use_dask = request.param
-        data = file_data_pair[in_csv_file](in_csv_file, use_dask=use_dask,
+        data = file_data_pair[in_csv_file](in_csv_file,
                                            blobs_relative_to_csv=True)
 
         setattr(data, "response_handler", check_response_regressions)
@@ -132,7 +132,7 @@ def insert_data_from_csv(db, request):
         if rec_count != -1:
             data = data[:rec_count]
 
-        loader = ParallelLoader(db)
+        loader = ParallelLoader(db, use_dask=use_dask)
         loader.ingest(data, batchsize=503,
                       numthreads=4,
                       stats=True,
@@ -200,11 +200,11 @@ def modify_data_from_csv(db, request):
         if hasattr(request, "param"):
             use_dask = request.param
         data = file_data_pair[in_csv_file](
-            in_csv_file, use_dask=use_dask, blobs_relative_to_csv=True)
+            in_csv_file, blobs_relative_to_csv=True)
         if rec_count != -1:
             data = data[:rec_count]
 
-        loader = ParallelQuerySet(db)
+        loader = ParallelQuerySet(db, use_dask=use_dask)
         loader.query(data, batchsize=99,
                      numthreads=1,
                      stats=True,

--- a/test/test_Parallel.py
+++ b/test/test_Parallel.py
@@ -94,10 +94,10 @@ def test_dask_dry_run(db: Connector):
 
     # Create generator with Dask
     generator = EntityDataCSV(
-        "./input/persons.adb.csv", use_dask=True, blobs_relative_to_csv=True)
+        "./input/persons.adb.csv", blobs_relative_to_csv=True)
 
     # Run ParallelLoader with dry_run=True
-    loader = ParallelLoader(db, dry_run=True)
+    loader = ParallelLoader(db, dry_run=True, use_dask=True)
     loader.ingest(generator, batchsize=503, numthreads=4, stats=True)
 
     # Verify no objects were created


### PR DESCRIPTION
## Summary
* Decouples `use_dask` from `CSVParser` so that it doesn't try to parse using dask explicitly based on the generator kwargs.
* Makes `use_dask` a property of `Parallelizer` (`ParallelQuery`, `ParallelLoader`, `ParallelQuerySet`).
* Automatically parses pandas dataframe to Dask dataframe in `DaskManager` if `use_dask` is enabled.
* Resolves #233.

## Verification
* Run tests successfully.

Fixes aperture-data/aperturedb-python#233