### PR TITLE
Fix: generalize and refactor connection pool from workflows

### DIFF
--- a/aperturedb/__init__.py
+++ b/aperturedb/__init__.py
@@ -91,3 +91,4 @@ except Exception as e:
 if __version__ != latest_version:
     logger.warning(
         f"The latest version of aperturedb is {latest_version}. You are using version {__version__}. It is recommended to upgrade.")
+from .ConnectionPool import ConnectionPool


### PR DESCRIPTION
Closes #598

Exported ConnectionPool in `__init__.py` to make it accessible directly from `aperturedb` module.