### PR TITLE
feat: Add CSV ingestion support for Frames

### DIFF
--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -16,6 +16,7 @@ from aperturedb.Connector import Connector
 from aperturedb.ConnectorRest import ConnectorRest
 from aperturedb.types import Blobs, CommandResponses, Commands
 from aperturedb.LoggingUtils import censor_tokens
+from aperturedb.Constants import BLOB_FIND_COMMANDS
 
 logger = logging.getLogger(__name__)
 
@@ -383,9 +384,7 @@ def map_response_to_handler(handler, query, query_blobs,  response, response_blo
         if is_list:
             for req, resp in zip(query[start:end], response[start:end]):
                 for k in req:
-                    blob_returning_commands = ["FindImage", "FindBlob", "FindVideo",
-                                               "FindDescriptor", "FindBoundingBox", "FindFrame"]
-                    if k in blob_returning_commands and "blobs" in req[k] and req[k]["blobs"]:
+                    if k in BLOB_FIND_COMMANDS and "blobs" in req[k] and req[k]["blobs"]:
                         count = resp[k]["returned"]
                         b_count += count
 

--- a/aperturedb/CommonLibrary.py
+++ b/aperturedb/CommonLibrary.py
@@ -384,7 +384,7 @@ def map_response_to_handler(handler, query, query_blobs,  response, response_blo
             for req, resp in zip(query[start:end], response[start:end]):
                 for k in req:
                     blob_returning_commands = ["FindImage", "FindBlob", "FindVideo",
-                                               "FindDescriptor", "FindBoundingBox"]
+                                               "FindDescriptor", "FindBoundingBox", "FindFrame"]
                     if k in blob_returning_commands and "blobs" in req[k] and req[k]["blobs"]:
                         count = resp[k]["returned"]
                         b_count += count

--- a/aperturedb/Constants.py
+++ b/aperturedb/Constants.py
@@ -2,18 +2,19 @@
 Shared constants for the ApertureDB Python SDK.
 """
 
-BLOB_ADD_COMMANDS = [
+BLOB_ADD_COMMANDS = (
     "AddImage",
     "AddDescriptor",
     "AddVideo",
     "AddBlob",
     "AddFrame"
-]
+)
 
-BLOB_FIND_COMMANDS = [
+BLOB_FIND_COMMANDS = (
     "FindImage",
     "FindDescriptor",
     "FindVideo",
     "FindBlob",
-    "FindFrame"
-]
+    "FindFrame",
+    "FindBoundingBox"
+)

--- a/aperturedb/Constants.py
+++ b/aperturedb/Constants.py
@@ -1,0 +1,19 @@
+"""
+Shared constants for the ApertureDB Python SDK.
+"""
+
+BLOB_ADD_COMMANDS = [
+    "AddImage",
+    "AddDescriptor",
+    "AddVideo",
+    "AddBlob",
+    "AddFrame"
+]
+
+BLOB_FIND_COMMANDS = [
+    "FindImage",
+    "FindDescriptor",
+    "FindVideo",
+    "FindBlob",
+    "FindFrame"
+]

--- a/aperturedb/DataModels.py
+++ b/aperturedb/DataModels.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated, List
-from typing import ClassVar, Optional
+from typing import ClassVar
 from uuid import uuid4
 from aperturedb.Query import ObjectType, PropertyType, RangeType
 

--- a/aperturedb/DataModels.py
+++ b/aperturedb/DataModels.py
@@ -72,6 +72,7 @@ class PolygonDataModel(IdentityDataModel):
 
 class FrameDataModel(BlobDataModel):
     """Frame data model for ApertureDB.
+    Inherits from BlobDataModel, making the `url` field required for ingestion.
     """
     type = ObjectType.FRAME
 

--- a/aperturedb/DataModels.py
+++ b/aperturedb/DataModels.py
@@ -73,8 +73,6 @@ class PolygonDataModel(IdentityDataModel):
 class FrameDataModel(BlobDataModel):
     """Frame data model for ApertureDB.
     """
-    url: Annotated[Optional[str], Field(
-        title="URL", description="URL to file, http, s3 or gs resource")] = None
     type = ObjectType.FRAME
 
 

--- a/aperturedb/DataModels.py
+++ b/aperturedb/DataModels.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated, List
-from typing import ClassVar
+from typing import ClassVar, Optional
 from uuid import uuid4
 from aperturedb.Query import ObjectType, PropertyType, RangeType
 
@@ -70,10 +70,11 @@ class PolygonDataModel(IdentityDataModel):
     type = ObjectType.POLYGON
 
 
-class FrameDataModel(BlobDataModel):
+class FrameDataModel(IdentityDataModel):
     """Frame data model for ApertureDB.
-    Inherits from BlobDataModel, making the `url` field required for ingestion.
     """
+    url: Annotated[Optional[str], Field(
+        title="URL", description="URL to file, http, s3 or gs resource")] = None
     type = ObjectType.FRAME
 
 

--- a/aperturedb/DataModels.py
+++ b/aperturedb/DataModels.py
@@ -70,7 +70,7 @@ class PolygonDataModel(IdentityDataModel):
     type = ObjectType.POLYGON
 
 
-class FrameDataModel(IdentityDataModel):
+class FrameDataModel(BlobDataModel):
     """Frame data model for ApertureDB.
     """
     type = ObjectType.FRAME

--- a/aperturedb/DataModels.py
+++ b/aperturedb/DataModels.py
@@ -70,7 +70,7 @@ class PolygonDataModel(IdentityDataModel):
     type = ObjectType.POLYGON
 
 
-class FrameDataModel(BlobDataModel):
+class FrameDataModel(IdentityDataModel):
     """Frame data model for ApertureDB.
     """
     type = ObjectType.FRAME

--- a/aperturedb/DataModels.py
+++ b/aperturedb/DataModels.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated, List
-from typing import ClassVar
+from typing import ClassVar, Optional
 from uuid import uuid4
 from aperturedb.Query import ObjectType, PropertyType, RangeType
 
@@ -73,6 +73,8 @@ class PolygonDataModel(IdentityDataModel):
 class FrameDataModel(BlobDataModel):
     """Frame data model for ApertureDB.
     """
+    url: Annotated[Optional[str], Field(
+        title="URL", description="URL to file, http, s3 or gs resource")] = None
     type = ObjectType.FRAME
 
 

--- a/aperturedb/DataModels.py
+++ b/aperturedb/DataModels.py
@@ -70,11 +70,9 @@ class PolygonDataModel(IdentityDataModel):
     type = ObjectType.POLYGON
 
 
-class FrameDataModel(IdentityDataModel):
+class FrameDataModel(BlobDataModel):
     """Frame data model for ApertureDB.
     """
-    url: Annotated[Optional[str], Field(
-        title="URL", description="URL to file, http, s3 or gs resource")] = None
     type = ObjectType.FRAME
 
 

--- a/aperturedb/Entities.py
+++ b/aperturedb/Entities.py
@@ -278,6 +278,7 @@ class Entities(Subscriptable):
 def load_entities_registry(custom_entities: List[str] = None) -> dict:
     from aperturedb.Polygons import Polygons
     from aperturedb.Images import Images
+    from aperturedb.Frames import Frames
     from aperturedb.Blobs import Blobs
     from aperturedb.BoundingBoxes import BoundingBoxes
     from aperturedb.Videos import Videos
@@ -287,6 +288,7 @@ def load_entities_registry(custom_entities: List[str] = None) -> dict:
     known_entities = {
         ObjectType.POLYGON.value: Polygons,
         ObjectType.IMAGE.value: Images,
+        ObjectType.FRAME.value: Frames,
         ObjectType.VIDEO.value: Videos,
         ObjectType.BOUNDING_BOX.value: BoundingBoxes,
         ObjectType.BLOB.value: Blobs,

--- a/aperturedb/FrameDataCSV.py
+++ b/aperturedb/FrameDataCSV.py
@@ -1,6 +1,14 @@
 from aperturedb.ImageDataCSV import ImageDataCSV
 
+
 class FrameDataCSV(ImageDataCSV):
     def __init__(self, *args, **kwargs):
         self.command = "AddFrame"
         super().__init__(*args, **kwargs)
+
+    def get_indices(self):
+        return {
+            "entity": {
+                "_Frame": self.get_indexed_properties()
+            }
+        }

--- a/aperturedb/FrameDataCSV.py
+++ b/aperturedb/FrameDataCSV.py
@@ -2,9 +2,13 @@ from aperturedb.ImageDataCSV import ImageDataCSV
 
 
 class FrameDataCSV(ImageDataCSV):
-    def __init__(self, *args, **kwargs):
-        self.command = "AddFrame"
-        super().__init__(*args, **kwargs)
+    """
+    **Helper class to ingest Frame data from a CSV file.**
+
+    This class extends ImageDataCSV and sets the insertion command to "AddFrame",
+    allowing frame files to be batch ingested from CSVs just like images.
+    """
+    command = "AddFrame"
 
     def get_indices(self):
         return {

--- a/aperturedb/FrameDataCSV.py
+++ b/aperturedb/FrameDataCSV.py
@@ -1,4 +1,5 @@
 from aperturedb.ImageDataCSV import ImageDataCSV
+from aperturedb.Query import ObjectType
 
 
 class FrameDataCSV(ImageDataCSV):
@@ -13,6 +14,6 @@ class FrameDataCSV(ImageDataCSV):
     def get_indices(self):
         return {
             "entity": {
-                "_Frame": self.get_indexed_properties()
+                ObjectType.FRAME.value: self.get_indexed_properties()
             }
         }

--- a/aperturedb/FrameDataCSV.py
+++ b/aperturedb/FrameDataCSV.py
@@ -1,0 +1,6 @@
+from aperturedb.ImageDataCSV import ImageDataCSV
+
+class FrameDataCSV(ImageDataCSV):
+    def __init__(self, *args, **kwargs):
+        self.command = "AddFrame"
+        super().__init__(*args, **kwargs)

--- a/aperturedb/Frames.py
+++ b/aperturedb/Frames.py
@@ -18,4 +18,5 @@ class Frames(Images):
     db_object = ObjectType.FRAME
 
     def __init__(self, client, batch_size=100, response=None, **kwargs):
-        super().__init__(client, batch_size=batch_size, response=response, **kwargs)
+        super().__init__(
+            client, batch_size=batch_size, response=response, **kwargs)

--- a/aperturedb/Frames.py
+++ b/aperturedb/Frames.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from aperturedb.Images import Images
+from aperturedb.Query import ObjectType
+
+
+class Frames(Images):
+    """
+    **The python wrapper of frame images in ApertureDB.**
+
+    Frames in ApertureDB are quite similar to images and so
+    are modeled in python as a subclass.
+
+
+    Args:
+        client: The database connector, perhaps as returned by `CommonLibrary.create_connector`
+    """
+    db_object = ObjectType.FRAME
+
+    def __init__(self, client, batch_size=100, response=None, **kwargs):
+        super().__init__(client, batch_size=batch_size, response=response, **kwargs)

--- a/aperturedb/ImageDataCSV.py
+++ b/aperturedb/ImageDataCSV.py
@@ -119,6 +119,8 @@ class ImageDataProcessor():
 
 
 class ImageDataCSV(CSVParser.CSVParser, ImageDataProcessor):
+    command = "AddImage"
+
     """**ApertureDB Image Data.**
 
     This class loads the Image Data which is present in a CSV file,
@@ -198,10 +200,6 @@ class ImageDataCSV(CSVParser.CSVParser, ImageDataProcessor):
 
         self.relative_path_prefix = os.path.dirname(self.filename) \
             if self.source_type == HEADER_PATH and self.blobs_relative_to_csv else ""
-
-        self.command = getattr(type(self), "command", None)
-        if self.command is None:
-            self.command = "AddImage"
 
     def getitem(self, idx):
         idx = self.df.index.start + idx

--- a/aperturedb/ImageDataCSV.py
+++ b/aperturedb/ImageDataCSV.py
@@ -199,7 +199,7 @@ class ImageDataCSV(CSVParser.CSVParser, ImageDataProcessor):
         self.relative_path_prefix = os.path.dirname(self.filename) \
             if self.source_type == HEADER_PATH and self.blobs_relative_to_csv else ""
 
-        self.command = getattr(self, "command", None)
+        self.command = getattr(type(self), "command", None)
         if self.command is None:
             self.command = "AddImage"
 

--- a/aperturedb/ImageDataCSV.py
+++ b/aperturedb/ImageDataCSV.py
@@ -199,7 +199,7 @@ class ImageDataCSV(CSVParser.CSVParser, ImageDataProcessor):
         self.relative_path_prefix = os.path.dirname(self.filename) \
             if self.source_type == HEADER_PATH and self.blobs_relative_to_csv else ""
 
-        self.command = getattr(self, "command", "AddImage")
+        self.command = getattr(self, "command", None) or "AddImage"
 
     def getitem(self, idx):
         idx = self.df.index.start + idx

--- a/aperturedb/ImageDataCSV.py
+++ b/aperturedb/ImageDataCSV.py
@@ -199,7 +199,9 @@ class ImageDataCSV(CSVParser.CSVParser, ImageDataProcessor):
         self.relative_path_prefix = os.path.dirname(self.filename) \
             if self.source_type == HEADER_PATH and self.blobs_relative_to_csv else ""
 
-        self.command = getattr(self, "command", None) or "AddImage"
+        self.command = getattr(self, "command", None)
+        if self.command is None:
+            self.command = "AddImage"
 
     def getitem(self, idx):
         idx = self.df.index.start + idx

--- a/aperturedb/ImageDataCSV.py
+++ b/aperturedb/ImageDataCSV.py
@@ -199,7 +199,7 @@ class ImageDataCSV(CSVParser.CSVParser, ImageDataProcessor):
         self.relative_path_prefix = os.path.dirname(self.filename) \
             if self.source_type == HEADER_PATH and self.blobs_relative_to_csv else ""
 
-        self.command = "AddImage"
+        self.command = getattr(self, "command", "AddImage")
 
     def getitem(self, idx):
         idx = self.df.index.start + idx

--- a/aperturedb/ImageDataCSV.py
+++ b/aperturedb/ImageDataCSV.py
@@ -119,8 +119,6 @@ class ImageDataProcessor():
 
 
 class ImageDataCSV(CSVParser.CSVParser, ImageDataProcessor):
-    command = "AddImage"
-
     """**ApertureDB Image Data.**
 
     This class loads the Image Data which is present in a CSV file,
@@ -173,6 +171,8 @@ class ImageDataCSV(CSVParser.CSVParser, ImageDataProcessor):
     id would be only inserted if it does not already exist in the database.
     :::
     """
+    command = "AddImage"
+
 
     def __init__(self, filename: str, check_image: bool = True, n_download_retries: int = 3, **kwargs):
 

--- a/aperturedb/ImageDataCSV.py
+++ b/aperturedb/ImageDataCSV.py
@@ -173,7 +173,6 @@ class ImageDataCSV(CSVParser.CSVParser, ImageDataProcessor):
     """
     command = "AddImage"
 
-
     def __init__(self, filename: str, check_image: bool = True, n_download_retries: int = 3, **kwargs):
 
         ImageDataProcessor.__init__(

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -1013,6 +1013,3 @@ def __getattr__(name: str):
         globals()[name] = Frames
         return Frames
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -1013,3 +1013,11 @@ def __getattr__(name: str):
         globals()[name] = Frames
         return Frames
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["np_arr_img_to_bytes", "image_to_bytes",
+           "rotate", "resolve", "Images", "Frames"]
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + ["Frames"])

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -1009,3 +1009,6 @@ def __getattr__(name: str):
         from aperturedb.Frames import Frames
         return Frames
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [k for k in globals().keys() if not k.startswith('_')] + ['Frames']

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -1015,15 +1015,4 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = [
-    "Any", "BytesIO", "Constraints", "DataFrame", "Dict", "Entities",
-    "Frames", "HTML", "Image", "Images", "Iterable", "List",
-    "ObjectType", "QueryBuilder", "TYPE_CHECKING", "Tuple", "Union",
-    "Utils", "annotations", "base64", "class_entity", "cv2", "display",
-    "execute_query", "image_to_bytes", "logger", "logging", "math",
-    "np", "np_arr_img_to_bytes", "plt", "resolve", "rotate", "widgets"
-]
 
-
-def __dir__():
-    return sorted(set(list(globals().keys()) + __all__))

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -1020,4 +1020,4 @@ __all__ = ["np_arr_img_to_bytes", "image_to_bytes",
 
 
 def __dir__():
-    return __all__
+    return sorted(set(list(globals().keys()) + __all__))

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -1015,8 +1015,14 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = ["np_arr_img_to_bytes", "image_to_bytes",
-           "rotate", "resolve", "Images", "Frames"]
+__all__ = [
+    "Any", "BytesIO", "Constraints", "DataFrame", "Dict", "Entities",
+    "Frames", "HTML", "Image", "Images", "Iterable", "List",
+    "ObjectType", "QueryBuilder", "TYPE_CHECKING", "Tuple", "Union",
+    "Utils", "annotations", "base64", "class_entity", "cv2", "display",
+    "execute_query", "image_to_bytes", "logger", "logging", "math",
+    "np", "np_arr_img_to_bytes", "plt", "resolve", "rotate", "widgets"
+]
 
 
 def __dir__():

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -1007,6 +1007,7 @@ class Images(Entities):
 def __getattr__(name: str):
     if name == "Frames":
         from aperturedb.Frames import Frames
+        globals()[name] = Frames
         return Frames
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -1015,15 +1015,5 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = [
-    "Any", "BytesIO", "Constraints", "DataFrame", "Dict", "Entities",
-    "Frames", "HTML", "Image", "Images", "Iterable", "List",
-    "ObjectType", "QueryBuilder", "TYPE_CHECKING", "Tuple", "Union",
-    "Utils", "base64", "class_entity", "cv2", "display",
-    "execute_query", "image_to_bytes", "logger", "logging", "math",
-    "np", "np_arr_img_to_bytes", "plt", "resolve", "rotate", "widgets"
-]
-
-
 def __dir__():
-    return sorted(list(globals().keys()) + ["Frames"])
+    return sorted(set(list(globals().keys()) + ["Frames"]))

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -3,7 +3,10 @@
 """
 
 from __future__ import annotations
-from typing import Any, Dict, Iterable, List, Tuple, Union
+from typing import Any, Dict, Iterable, List, Tuple, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aperturedb.Frames import Frames
 import cv2
 import math
 import numpy as np
@@ -1010,6 +1013,10 @@ def __getattr__(name: str):
         globals()[name] = Frames
         return Frames
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return __all__
 
 
 __all__ = ["np_arr_img_to_bytes", "image_to_bytes",

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -1015,9 +1015,9 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-def __dir__():
-    return __all__
-
-
 __all__ = ["np_arr_img_to_bytes", "image_to_bytes",
            "rotate", "resolve", "Images", "Frames"]
+
+
+def __dir__():
+    return __all__

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -1004,4 +1004,8 @@ class Images(Entities):
 
 
 # Shim for backward compatibility
-from aperturedb.Frames import Frames  # noqa: F401
+def __getattr__(name: str):
+    if name == "Frames":
+        from aperturedb.Frames import Frames
+        return Frames
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -1001,3 +1001,7 @@ class Images(Entities):
             print("Cannot retrieved properties")
 
         return return_dictionary
+
+
+# Shim for backward compatibility
+from aperturedb.Frames import Frames  # noqa: F401

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -1019,7 +1019,7 @@ __all__ = [
     "Any", "BytesIO", "Constraints", "DataFrame", "Dict", "Entities",
     "Frames", "HTML", "Image", "Images", "Iterable", "List",
     "ObjectType", "QueryBuilder", "TYPE_CHECKING", "Tuple", "Union",
-    "Utils", "annotations", "base64", "class_entity", "cv2", "display",
+    "Utils", "base64", "class_entity", "cv2", "display",
     "execute_query", "image_to_bytes", "logger", "logging", "math",
     "np", "np_arr_img_to_bytes", "plt", "resolve", "rotate", "widgets"
 ]

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -1001,20 +1001,3 @@ class Images(Entities):
             print("Cannot retrieved properties")
 
         return return_dictionary
-
-
-class Frames(Images):
-    """
-    **The python wrapper of frame images in ApertureDB.**
-
-    Frames in ApertureDB are quite similar to images and so
-    are modeled in python as a subclass.
-
-
-    Args:
-        client: The database connector, perhaps as returned by `CommonLibrary.create_connector`
-    """
-    db_object = ObjectType.FRAME
-
-    def __init__(self, client, batch_size=100, response=None, **kwargs):
-        super().__init__(client, batch_size=batch_size, response=response, **kwargs)

--- a/aperturedb/Images.py
+++ b/aperturedb/Images.py
@@ -1012,4 +1012,5 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = [k for k in globals().keys() if not k.startswith('_')] + ['Frames']
+__all__ = ["np_arr_img_to_bytes", "image_to_bytes",
+           "rotate", "resolve", "Images", "Frames"]

--- a/aperturedb/MLCroissant.py
+++ b/aperturedb/MLCroissant.py
@@ -273,7 +273,7 @@ class MLCroissantRecordSet(Subscriptable):
         indexes_to_create = []
         for command in q:
             cmd = list(command.keys())[-1]
-            if cmd in ["AddImage", "AddBlob", "AddVideo"]:
+            if cmd in ["AddImage", "AddBlob", "AddVideo", "AddFrame"]:
                 continue
             indexable_entity = command[list(command.keys())[-1]]["class"]
             if indexable_entity not in self.indexed_entities:

--- a/aperturedb/PyTorchDataset.py
+++ b/aperturedb/PyTorchDataset.py
@@ -37,7 +37,7 @@ class ApertureDBDataset(data.Dataset):
 
         allowed_find_commands = {
             "FindImage", "FindVideo", "FindBlob",
-            "FindDescriptor", "FindBoundingBox"
+            "FindDescriptor", "FindBoundingBox", "FindFrame"
         }
 
         if self.command_idx is not None:
@@ -61,7 +61,7 @@ class ApertureDBDataset(data.Dataset):
                     self.command_name = name
 
         if self.command_idx is None:
-            msg = "Query error. The query must contain at least one supported blob-returning Find command (e.g., FindImage, FindVideo, FindBlob). The first one encountered will be used."
+            msg = "Query error. The query must contain at least one supported blob-returning Find command (e.g., FindImage, FindVideo, FindBlob, FindFrame). The first one encountered will be used."
             logger.error(msg)
             raise ValueError(msg)
 
@@ -111,7 +111,7 @@ class ApertureDBDataset(data.Dataset):
         blob = self.batch_blobs[idx]
         label = self.batch_labels[idx]
 
-        if self.command_name == "FindImage":
+        if self.command_name in ("FindImage", "FindFrame"):
             nparr = np.frombuffer(blob, dtype=np.uint8)
             blob = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
             if blob is None:

--- a/aperturedb/Query.py
+++ b/aperturedb/Query.py
@@ -227,7 +227,7 @@ def generate_add_query(
                 params.pop("properties", None)
                 query.append(
                     QueryBuilder.find_command(obj.type.value, params=params))
-        if obj.type in [ObjectType.IMAGE, ObjectType.VIDEO, ObjectType.BLOB]:
+        if obj.type in [ObjectType.IMAGE, ObjectType.VIDEO, ObjectType.BLOB, ObjectType.FRAME]:
             # Do not send blob, if Node has been added to set of commands.
             if obj.id not in cached:
                 if obj.url:

--- a/aperturedb/TensorFlowDataset.py
+++ b/aperturedb/TensorFlowDataset.py
@@ -14,7 +14,7 @@ class ApertureDBTensorFlowDataset:
     This class implements a TensorFlow Dataset for ApertureDB.
     It is used to load blobs returned by a `Find*` command from ApertureDB into a TensorFlow model.
     It can be initialized with a query that will be used to retrieve
-    the blobs from ApertureDB. Note that only `FindImage` blobs are decoded via OpenCV.
+    the blobs from ApertureDB. Note that only `FindImage` and `FindFrame` blobs are decoded via OpenCV.
     """
 
     def __init__(self, client: Connector, query, label_prop=None, batch_size=1, command_idx=None):

--- a/aperturedb/TensorFlowDataset.py
+++ b/aperturedb/TensorFlowDataset.py
@@ -35,7 +35,7 @@ class ApertureDBTensorFlowDataset:
 
         allowed_find_commands = {
             "FindImage", "FindVideo", "FindBlob",
-            "FindDescriptor", "FindBoundingBox"
+            "FindDescriptor", "FindBoundingBox", "FindFrame"
         }
 
         if self.command_idx is not None:
@@ -59,7 +59,7 @@ class ApertureDBTensorFlowDataset:
                     self.command_name = name
 
         if self.command_idx is None:
-            msg = "Query error. The query must contain at least one supported blob-returning Find command (e.g., FindImage, FindVideo, FindBlob). The first one encountered will be used."
+            msg = "Query error. The query must contain at least one supported blob-returning Find command (e.g., FindImage, FindVideo, FindBlob, FindFrame). The first one encountered will be used."
             logger.error(msg)
             raise ValueError(msg)
 
@@ -177,7 +177,7 @@ class ApertureDBTensorFlowDataset:
             blob = self.batch_blobs[idx]
             label = self.batch_labels[idx]
 
-            if self.command_name == "FindImage":
+            if self.command_name in ("FindImage", "FindFrame"):
                 nparr = np.frombuffer(blob, dtype=np.uint8)
                 blob = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
                 if blob is None:
@@ -226,7 +226,7 @@ class ApertureDBTensorFlowDataset:
             else:
                 self.label_type = tf.string
 
-        if self.command_name == "FindImage":
+        if self.command_name in ("FindImage", "FindFrame"):
             tensor_shape = (None, None, 3)
             tensor_dtype = tf.uint8
         else:

--- a/aperturedb/cli/ingest.py
+++ b/aperturedb/cli/ingest.py
@@ -194,7 +194,7 @@ def from_csv(filepath: Annotated[str, typer.Argument(
     Ingest data from a pre generated CSV file.
     """
     from aperturedb.ImageDataCSV import ImageDataCSV
-    from aperturedb.BBoxDataCSV import BBoxDataCSV
+    from aperturedb.FrameDataCSV import FrameDataCSV
     from aperturedb.EntityDataCSV import EntityDataCSV
     from aperturedb.BlobDataCSV import BlobDataCSV
     from aperturedb.ConnectionDataCSV import ConnectionDataCSV
@@ -210,6 +210,7 @@ def from_csv(filepath: Annotated[str, typer.Argument(
         IngestType.DESCRIPTOR: DescriptorDataCSV,
         IngestType.DESCRIPTORSET: DescriptorSetDataCSV,
         IngestType.ENTITY: EntityDataCSV,
+        IngestType.FRAME: FrameDataCSV,
         IngestType.IMAGE: ImageDataCSV,
         IngestType.POLYGON: PolygonDataCSV,
         IngestType.VIDEO: VideoDataCSV

--- a/aperturedb/cli/ingest.py
+++ b/aperturedb/cli/ingest.py
@@ -195,6 +195,7 @@ def from_csv(filepath: Annotated[str, typer.Argument(
     """
     from aperturedb.ImageDataCSV import ImageDataCSV
     from aperturedb.FrameDataCSV import FrameDataCSV
+    from aperturedb.BBoxDataCSV import BBoxDataCSV
     from aperturedb.EntityDataCSV import EntityDataCSV
     from aperturedb.BlobDataCSV import BlobDataCSV
     from aperturedb.ConnectionDataCSV import ConnectionDataCSV

--- a/aperturedb/transformers/clip_pytorch_embeddings.py
+++ b/aperturedb/transformers/clip_pytorch_embeddings.py
@@ -95,7 +95,7 @@ class CLIPPyTorchEmbeddings(Transformer):
                     except Exception as e:
                         logger.warning(
                             f"Failed to generate embedding or descriptor: {e}", exc_info=True)
-            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob"]:
+            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob", "AddFrame"]:
                 blob_index += 1
 
         x[0].extend(new_descriptors)

--- a/aperturedb/transformers/clip_pytorch_embeddings.py
+++ b/aperturedb/transformers/clip_pytorch_embeddings.py
@@ -1,3 +1,4 @@
+from aperturedb.Constants import BLOB_ADD_COMMANDS
 import hashlib
 import logging
 from aperturedb.Subscriptable import Subscriptable
@@ -95,7 +96,7 @@ class CLIPPyTorchEmbeddings(Transformer):
                     except Exception as e:
                         logger.warning(
                             f"Failed to generate embedding or descriptor: {e}", exc_info=True)
-            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob", "AddFrame"]:
+            if cmd_name in BLOB_ADD_COMMANDS:
                 blob_index += 1
 
         x[0].extend(new_descriptors)

--- a/aperturedb/transformers/common_properties.py
+++ b/aperturedb/transformers/common_properties.py
@@ -49,7 +49,7 @@ class CommonProperties(Transformer):
                 if isinstance(cmd_dict, dict) and len(cmd_dict) > 0:
                     cmd_name = next(iter(cmd_dict.keys()))
 
-                if cmd_name in ["AddImage", "AddVideo", "AddBoundingBox", "AddPolygon"]:
+                if cmd_name in ["AddImage", "AddVideo", "AddBoundingBox", "AddPolygon", "AddFrame"]:
                     src_properties = cmd_dict[cmd_name].setdefault(
                         "properties", {})
                     self._apply_common_properties(src_properties)

--- a/aperturedb/transformers/facenet_pytorch_embeddings.py
+++ b/aperturedb/transformers/facenet_pytorch_embeddings.py
@@ -1,3 +1,4 @@
+from aperturedb.Constants import BLOB_ADD_COMMANDS
 import hashlib
 import logging
 from aperturedb.Subscriptable import Subscriptable
@@ -100,7 +101,7 @@ class FacenetPyTorchEmbeddings(Transformer):
                     except Exception as e:
                         logger.warning(
                             f"Failed to generate embedding or descriptor: {e}", exc_info=True)
-            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob", "AddFrame"]:
+            if cmd_name in BLOB_ADD_COMMANDS:
                 blob_index += 1
 
         x[0].extend(new_descriptors)

--- a/aperturedb/transformers/facenet_pytorch_embeddings.py
+++ b/aperturedb/transformers/facenet_pytorch_embeddings.py
@@ -100,7 +100,7 @@ class FacenetPyTorchEmbeddings(Transformer):
                     except Exception as e:
                         logger.warning(
                             f"Failed to generate embedding or descriptor: {e}", exc_info=True)
-            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob"]:
+            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob", "AddFrame"]:
                 blob_index += 1
 
         x[0].extend(new_descriptors)

--- a/aperturedb/transformers/image_properties.py
+++ b/aperturedb/transformers/image_properties.py
@@ -34,7 +34,7 @@ class ImageProperties(Transformer):
             if isinstance(cmd_dict, dict) and len(cmd_dict) > 0:
                 cmd_name = next(iter(cmd_dict.keys()))
 
-            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob"]:
+            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob", "AddFrame"]:
                 if blob_index >= len(x[1]):
                     logger.warning(
                         "Missing blob for command %s (expected at index %d), stopping property processing for this transaction.",
@@ -66,7 +66,7 @@ class ImageProperties(Transformer):
                 logger.exception(
                     "Error applying image properties", stack_info=True)
 
-            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob"]:
+            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob", "AddFrame"]:
                 blob_index += 1
 
         return x

--- a/aperturedb/transformers/image_properties.py
+++ b/aperturedb/transformers/image_properties.py
@@ -1,3 +1,4 @@
+from aperturedb.Constants import BLOB_ADD_COMMANDS
 from aperturedb.transformers.transformer import Transformer
 from aperturedb.Subscriptable import Subscriptable
 
@@ -34,7 +35,7 @@ class ImageProperties(Transformer):
             if isinstance(cmd_dict, dict) and len(cmd_dict) > 0:
                 cmd_name = next(iter(cmd_dict.keys()))
 
-            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob", "AddFrame"]:
+            if cmd_name in BLOB_ADD_COMMANDS:
                 if blob_index >= len(x[1]):
                     logger.warning(
                         "Missing blob for command %s (expected at index %d), stopping property processing for this transaction.",
@@ -66,7 +67,7 @@ class ImageProperties(Transformer):
                 logger.exception(
                     "Error applying image properties", stack_info=True)
 
-            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob", "AddFrame"]:
+            if cmd_name in BLOB_ADD_COMMANDS:
                 blob_index += 1
 
         return x

--- a/aperturedb/transformers/transformer.py
+++ b/aperturedb/transformers/transformer.py
@@ -67,7 +67,7 @@ class Transformer(Subscriptable):
             command = None
             if isinstance(c, dict) and len(c) > 0:
                 command = next(iter(c.keys()))
-            if command in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob"]:
+            if command in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob", "AddFrame"]:
                 self._blob_index.append(i)
                 bc += 1
             # Kept for backward compatibility

--- a/aperturedb/transformers/transformer.py
+++ b/aperturedb/transformers/transformer.py
@@ -1,3 +1,4 @@
+from aperturedb.Constants import BLOB_ADD_COMMANDS
 from aperturedb.Subscriptable import Subscriptable
 from aperturedb.CommonLibrary import create_connector
 from aperturedb.Utils import Utils
@@ -67,7 +68,7 @@ class Transformer(Subscriptable):
             command = None
             if isinstance(c, dict) and len(c) > 0:
                 command = next(iter(c.keys()))
-            if command in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob", "AddFrame"]:
+            if command in BLOB_ADD_COMMANDS:
                 self._blob_index.append(i)
                 bc += 1
             # Kept for backward compatibility

--- a/aperturedb/transformers/video_properties.py
+++ b/aperturedb/transformers/video_properties.py
@@ -32,7 +32,7 @@ class VideoProperties(Transformer):
             if isinstance(cmd_dict, dict) and len(cmd_dict) > 0:
                 cmd_name = next(iter(cmd_dict.keys()))
 
-            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob"]:
+            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob", "AddFrame"]:
                 if blob_index >= len(x[1]):
                     logger.warning(
                         "Missing blob for command %s (expected at index %d), stopping property processing for this transaction.",
@@ -59,7 +59,7 @@ class VideoProperties(Transformer):
                 logger.exception(
                     "Error applying video properties", stack_info=True)
 
-            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob"]:
+            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob", "AddFrame"]:
                 blob_index += 1
 
         return x

--- a/aperturedb/transformers/video_properties.py
+++ b/aperturedb/transformers/video_properties.py
@@ -1,3 +1,4 @@
+from aperturedb.Constants import BLOB_ADD_COMMANDS
 from aperturedb.transformers.transformer import Transformer
 from aperturedb.Subscriptable import Subscriptable
 
@@ -32,7 +33,7 @@ class VideoProperties(Transformer):
             if isinstance(cmd_dict, dict) and len(cmd_dict) > 0:
                 cmd_name = next(iter(cmd_dict.keys()))
 
-            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob", "AddFrame"]:
+            if cmd_name in BLOB_ADD_COMMANDS:
                 if blob_index >= len(x[1]):
                     logger.warning(
                         "Missing blob for command %s (expected at index %d), stopping property processing for this transaction.",
@@ -59,7 +60,7 @@ class VideoProperties(Transformer):
                 logger.exception(
                     "Error applying video properties", stack_info=True)
 
-            if cmd_name in ["AddImage", "AddDescriptor", "AddVideo", "AddBlob", "AddFrame"]:
+            if cmd_name in BLOB_ADD_COMMANDS:
                 blob_index += 1
 
         return x

--- a/test/run_test_container.sh
+++ b/test/run_test_container.sh
@@ -7,9 +7,9 @@ cd "${SCRIPT_DIR}"
 
 function check_containers_networks(){
     echo "Running containers and networks cleanup"
-    docker ps
+    docker ps || true
     echo "Existing networks"
-    docker network ls
+    docker network ls || true
 }
 
 function get_sudo() {
@@ -216,4 +216,4 @@ fi
 
 echo "Tests completed"
 echo " --- Runner name: ${RUNNER_NAME} ---"
-check_containers_networks || true
+check_containers_networks

--- a/test/run_test_container.sh
+++ b/test/run_test_container.sh
@@ -66,7 +66,7 @@ function teardown() {
         docker network rm "${RUNNER_NAME}_non_http_default" || true
     fi
     echo "Cleaning up generated volumes..."
-    $(get_sudo) rm -rf "${SCRIPT_DIR}/aperturedb"
+    $(get_sudo) rm -rf "${SCRIPT_DIR}/aperturedb" || true
 }
 trap teardown EXIT
 
@@ -216,4 +216,4 @@ fi
 
 echo "Tests completed"
 echo " --- Runner name: ${RUNNER_NAME} ---"
-check_containers_networks
+check_containers_networks || true

--- a/test/test_DataModels.py
+++ b/test/test_DataModels.py
@@ -3,6 +3,7 @@ from aperturedb.Query import ObjectType
 from pydantic import ValidationError
 import pytest
 
+
 def test_FrameDataModel():
     # url is optional to avoid breaking existing users
     frame_no_url = FrameDataModel()

--- a/test/test_DataModels.py
+++ b/test/test_DataModels.py
@@ -1,11 +1,12 @@
 from aperturedb.DataModels import FrameDataModel
 from aperturedb.Query import ObjectType
+from pydantic import ValidationError
 import pytest
 
 
 def test_FrameDataModel():
     # Verify that url is a required field because it inherits from BlobDataModel
-    with pytest.raises(ValueError):
+    with pytest.raises((ValueError, ValidationError)):
         # This should fail because url is missing
         FrameDataModel()
 

--- a/test/test_DataModels.py
+++ b/test/test_DataModels.py
@@ -1,0 +1,16 @@
+from aperturedb.DataModels import FrameDataModel
+from aperturedb.Query import ObjectType
+import pytest
+
+
+def test_FrameDataModel():
+    # Verify that url is a required field because it inherits from BlobDataModel
+    with pytest.raises(ValueError):
+        # This should fail because url is missing
+        FrameDataModel()
+
+    # Verify that when url is provided, the model instantiates correctly
+    frame = FrameDataModel(url="http://example.com/frame.jpg")
+    assert frame.url == "http://example.com/frame.jpg"
+    assert frame.type == ObjectType.FRAME
+    assert frame.id is not None  # Should have a default UUID generated

--- a/test/test_DataModels.py
+++ b/test/test_DataModels.py
@@ -6,7 +6,7 @@ import pytest
 
 def test_FrameDataModel():
     # Verify that url is a required field because it inherits from BlobDataModel
-    with pytest.raises((ValueError, ValidationError)):
+    with pytest.raises(ValidationError):
         # This should fail because url is missing
         FrameDataModel()
 

--- a/test/test_DataModels.py
+++ b/test/test_DataModels.py
@@ -1,11 +1,13 @@
+from pydantic import ValidationError
 from aperturedb.DataModels import FrameDataModel
 from aperturedb.Query import ObjectType
+import pytest
 
 
 def test_FrameDataModel():
-    # url is optional to avoid breaking existing users
-    frame_no_url = FrameDataModel()
-    assert frame_no_url.url is None
+    # url is required, so instantiating without it should raise a ValidationError
+    with pytest.raises(ValidationError):
+        FrameDataModel()
 
     # Verify that when url is provided, the model instantiates correctly
     frame = FrameDataModel(url="http://example.com/frame.jpg")

--- a/test/test_DataModels.py
+++ b/test/test_DataModels.py
@@ -1,7 +1,5 @@
 from aperturedb.DataModels import FrameDataModel
 from aperturedb.Query import ObjectType
-from pydantic import ValidationError
-import pytest
 
 
 def test_FrameDataModel():

--- a/test/test_DataModels.py
+++ b/test/test_DataModels.py
@@ -3,12 +3,10 @@ from aperturedb.Query import ObjectType
 from pydantic import ValidationError
 import pytest
 
-
 def test_FrameDataModel():
-    # Verify that url is a required field because it inherits from BlobDataModel
-    with pytest.raises(ValidationError):
-        # This should fail because url is missing
-        FrameDataModel()
+    # url is optional to avoid breaking existing users
+    frame_no_url = FrameDataModel()
+    assert frame_no_url.url is None
 
     # Verify that when url is provided, the model instantiates correctly
     frame = FrameDataModel(url="http://example.com/frame.jpg")

--- a/test/test_Entities.py
+++ b/test/test_Entities.py
@@ -1,0 +1,9 @@
+from aperturedb.Entities import load_entities_registry
+from aperturedb.Query import ObjectType
+from aperturedb.Frames import Frames
+import pytest
+
+def test_load_entities_registry_frames():
+    registry = load_entities_registry()
+    assert ObjectType.FRAME.value in registry
+    assert registry[ObjectType.FRAME.value] is Frames

--- a/test/test_Entities.py
+++ b/test/test_Entities.py
@@ -1,7 +1,6 @@
 from aperturedb.Entities import load_entities_registry
 from aperturedb.Query import ObjectType
 from aperturedb.Frames import Frames
-import pytest
 
 
 def test_load_entities_registry_frames():

--- a/test/test_Entities.py
+++ b/test/test_Entities.py
@@ -3,6 +3,7 @@ from aperturedb.Query import ObjectType
 from aperturedb.Frames import Frames
 import pytest
 
+
 def test_load_entities_registry_frames():
     registry = load_entities_registry()
     assert ObjectType.FRAME.value in registry

--- a/test/test_FrameDataCSV.py
+++ b/test/test_FrameDataCSV.py
@@ -1,5 +1,3 @@
-import pytest
-import pandas as pd
 import tempfile
 import os
 from aperturedb.FrameDataCSV import FrameDataCSV

--- a/test/test_FrameDataCSV.py
+++ b/test/test_FrameDataCSV.py
@@ -4,7 +4,9 @@ from aperturedb.FrameDataCSV import FrameDataCSV
 
 
 def test_FrameDataCSV_command():
-    with tempfile.NamedTemporaryFile(suffix=".csv", mode="w", delete=False) as f:
+    with tempfile.NamedTemporaryFile(
+        suffix=".csv", mode="w", delete=False
+    ) as f:
         f.write("url,id\nhttp://example.com/frame.jpg,1\n")
         f.close()
 

--- a/test/test_FrameDataCSV.py
+++ b/test/test_FrameDataCSV.py
@@ -1,0 +1,25 @@
+import pytest
+import pandas as pd
+import tempfile
+import os
+from aperturedb.FrameDataCSV import FrameDataCSV
+
+
+def test_FrameDataCSV_command():
+    with tempfile.NamedTemporaryFile(suffix=".csv", mode="w", delete=False) as f:
+        f.write("url,id\nhttp://example.com/frame.jpg,1\n")
+        f.close()
+
+        try:
+            # We don't actually need the image since check_image=False
+            frame_data = FrameDataCSV(f.name, check_image=False)
+
+            assert frame_data.command == "AddFrame", f"Expected AddFrame, got {
+                frame_data.command}"
+
+            indices = frame_data.get_indices()
+            assert "entity" in indices
+            assert "_Frame" in indices["entity"]
+            assert indices["entity"]["_Frame"] == frame_data.get_indexed_properties()
+        finally:
+            os.remove(f.name)

--- a/test/test_FrameDataCSV.py
+++ b/test/test_FrameDataCSV.py
@@ -14,8 +14,8 @@ def test_FrameDataCSV_command():
             # We don't actually need the image since check_image=False
             frame_data = FrameDataCSV(f.name, check_image=False)
 
-            assert frame_data.command == "AddFrame", f"Expected AddFrame, got {
-                frame_data.command}"
+            cmd = frame_data.command
+            assert cmd == "AddFrame", f"Expected AddFrame, got {cmd}"
 
             indices = frame_data.get_indices()
             assert "entity" in indices

--- a/test/test_FrameDataCSV.py
+++ b/test/test_FrameDataCSV.py
@@ -1,6 +1,7 @@
 import tempfile
 import os
 from aperturedb.FrameDataCSV import FrameDataCSV
+from aperturedb.Query import ObjectType
 
 
 def test_FrameDataCSV_command():
@@ -8,18 +9,18 @@ def test_FrameDataCSV_command():
         suffix=".csv", mode="w", delete=False
     ) as f:
         f.write("url,id\nhttp://example.com/frame.jpg,1\n")
-        f.close()
 
-        try:
-            # We don't actually need the image since check_image=False
-            frame_data = FrameDataCSV(f.name, check_image=False)
+    try:
+        # We don't actually need the image since check_image=False
+        frame_data = FrameDataCSV(f.name, check_image=False)
 
-            cmd = frame_data.command
-            assert cmd == "AddFrame", f"Expected AddFrame, got {cmd}"
+        cmd = frame_data.command
+        assert cmd == "AddFrame", f"Expected AddFrame, got {cmd}"
 
-            indices = frame_data.get_indices()
-            assert "entity" in indices
-            assert "_Frame" in indices["entity"]
-            assert indices["entity"]["_Frame"] == frame_data.get_indexed_properties()
-        finally:
-            os.remove(f.name)
+        indices = frame_data.get_indices()
+        assert "entity" in indices
+        frame_type = ObjectType.FRAME.value
+        assert frame_type in indices["entity"]
+        assert indices["entity"][frame_type] == frame_data.get_indexed_properties()
+    finally:
+        os.remove(f.name)

--- a/test/test_Frames.py
+++ b/test/test_Frames.py
@@ -1,0 +1,15 @@
+from aperturedb.Frames import Frames
+from aperturedb.Query import ObjectType
+
+
+class MockClient:
+    def __init__(self):
+        pass
+
+
+def test_Frames_init():
+    client = MockClient()
+    frame = Frames(client)
+    assert frame.client == client
+    assert frame.db_object.value == "_Frame"
+    assert frame.db_object == ObjectType.FRAME

--- a/test/test_Frames.py
+++ b/test/test_Frames.py
@@ -13,3 +13,15 @@ def test_Frames_init():
     assert frame.client == client
     assert frame.db_object.value == "_Frame"
     assert frame.db_object == ObjectType.FRAME
+
+
+def test_Frames_backward_compatibility_import():
+    # Verify that importing Frames from aperturedb.Images resolves correctly
+    import aperturedb.Images
+    from aperturedb.Images import Frames as ImagesFrames
+
+    assert ImagesFrames is Frames
+
+    # Verify it is cached in the module's globals
+    assert "Frames" in aperturedb.Images.__dict__
+    assert aperturedb.Images.__dict__["Frames"] is Frames

--- a/test/test_Frames.py
+++ b/test/test_Frames.py
@@ -9,9 +9,9 @@ class MockClient:
 
 def test_Frames_init():
     client = MockClient()
-    frame = Frames(client)
-    assert frame.client == client
-    assert frame.db_object == ObjectType.FRAME
+    frames = Frames(client)
+    assert frames.client == client
+    assert frames.db_object == ObjectType.FRAME
 
 
 def test_Frames_backward_compatibility_import():

--- a/test/test_Frames.py
+++ b/test/test_Frames.py
@@ -11,7 +11,6 @@ def test_Frames_init():
     client = MockClient()
     frame = Frames(client)
     assert frame.client == client
-    assert frame.db_object.value == "_Frame"
     assert frame.db_object == ObjectType.FRAME
 
 

--- a/test/test_cli_ingest.py
+++ b/test/test_cli_ingest.py
@@ -10,7 +10,6 @@ def test_from_csv_frame_type():
 
         with patch.object(aperturedb.FrameDataCSV, "FrameDataCSV") as mock_csv_class:
             mock_data = MagicMock()
-            mock_data.__len__.return_value = 10
             mock_csv_class.return_value = mock_data
 
             from_csv(filepath="dummy.csv",

--- a/test/test_cli_ingest.py
+++ b/test/test_cli_ingest.py
@@ -1,0 +1,21 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from aperturedb.cli.ingest import from_csv, IngestType
+
+
+def test_from_csv_frame_type():
+    import aperturedb.FrameDataCSV
+
+    with patch("aperturedb.cli.ingest._process_data") as mock_process_data:
+        mock_process_data.return_value = None
+
+        with patch.object(aperturedb.FrameDataCSV, "FrameDataCSV") as mock_csv_class:
+            mock_data = MagicMock()
+            mock_data.__len__.return_value = 10
+            mock_csv_class.return_value = mock_data
+
+            from_csv(filepath="dummy.csv",
+                     ingest_type=IngestType.FRAME, sample_count=5)
+
+            mock_csv_class.assert_called_once_with(
+                "dummy.csv", use_dask=False, blobs_relative_to_csv=True)

--- a/test/test_cli_ingest.py
+++ b/test/test_cli_ingest.py
@@ -17,3 +17,4 @@ def test_from_csv_frame_type():
 
             mock_csv_class.assert_called_once_with(
                 "dummy.csv", use_dask=False, blobs_relative_to_csv=True)
+            mock_process_data.assert_called_once()

--- a/test/test_cli_ingest.py
+++ b/test/test_cli_ingest.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import patch, MagicMock
 from aperturedb.cli.ingest import from_csv, IngestType
 

--- a/test/test_tf_connector.py
+++ b/test/test_tf_connector.py
@@ -199,3 +199,44 @@ class TestTfDatasets():
                 assert label.numpy() == 1
                 count += 1
             assert count == 1
+
+    def test_findFrame_mocked(self):
+        from unittest.mock import patch
+        import tensorflow as tf
+        import numpy as np
+        import cv2
+
+        class DummyClient:
+            def clone(self):
+                return self
+
+            def get_last_response_str(self):
+                return ""
+
+        query = [{"FindFrame": {"results": {"list": ["prop"]}}}]
+
+        with patch('aperturedb.TensorFlowDataset.execute_query') as mock_exec:
+            def side_effect(*args, **kwargs):
+                batch_dict = {"total_elements": 1}
+                entities = [{"prop": 1}]
+                r = [{"FindFrame": {"batch": batch_dict, "entities": entities}}]
+                img = np.zeros((10, 10, 3), dtype=np.uint8)
+                _, b_img = cv2.imencode('.jpg', img)
+                b = [b_img.tobytes()]
+                return None, r, b
+
+            mock_exec.side_effect = side_effect
+            dataset_wrapper = ApertureDBTensorFlowDataset(
+                DummyClient(), query, label_prop="prop")
+            dataset = dataset_wrapper.get_dataset()
+
+            assert dataset.element_spec[1].dtype == tf.int32
+            # Since FindFrame behaves like FindImage, it should decode to a tensor (not string)
+            assert dataset.element_spec[0].dtype == tf.uint8
+
+            count = 0
+            for data, label in dataset:
+                assert data.shape == (10, 10, 3)
+                assert label.numpy() == 1
+                count += 1
+            assert count == 1

--- a/test/test_torch_connector.py
+++ b/test/test_torch_connector.py
@@ -174,3 +174,40 @@ class TestTorchDatasets():
                 assert blob == b"mock_video_bytes"
                 assert label == 1
                 break
+
+    def test_findFrame_mocked(self):
+        from unittest.mock import patch
+        import numpy as np
+        import cv2
+        import torch
+
+        class DummyClient:
+            def clone(self):
+                return self
+
+            def get_last_response_str(self):
+                return ""
+
+        query = [{"FindFrame": {"results": {"list": ["prop"]}}}]
+
+        with patch('aperturedb.PyTorchDataset.execute_query') as mock_exec:
+            def side_effect(*args, **kwargs):
+                batch_dict = {"total_elements": 1}
+                entities = [{"prop": 1}]
+                r = [{"FindFrame": {"batch": batch_dict, "entities": entities}}]
+                img = np.zeros((10, 10, 3), dtype=np.uint8)
+                is_success, buffer = cv2.imencode(".jpg", img)
+                b = [buffer.tobytes()]
+                return None, r, b
+
+            mock_exec.side_effect = side_effect
+            dataset = PyTorchDataset.ApertureDBDataset(
+                DummyClient(), query, label_prop="prop")
+
+            assert len(dataset) == 1
+            for blob, label in dataset:
+                assert isinstance(blob, np.ndarray)
+                assert blob.shape == (10, 10, 3)
+                assert isinstance(label, int)
+                assert label == 1
+                break


### PR DESCRIPTION
Closes #70

This PR adds a `FrameDataCSV` class which simply inherits from `ImageDataCSV` and overrides the command to `AddFrame`. It also registers `IngestType.FRAME` in the CLI, closing the loop on Frame OM and ingestion support without duplicating the complex loading/validation logic of Images.